### PR TITLE
docs(import): add Android Runtime Dalvik/ART notes

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -62,6 +62,7 @@
   - [compileSdk and targetSdk Version Mappings](android-dev/compilesdk-and-targetsdk-version-mappings.md)
   - [Ionic](software-engineering/android-app-development/ionic.md)
   - [Quasar.js](software-engineering/android-app-development/quasar.js.md)
+  - [Android Runtime - How Dalvik and ART Work](software-engineering/android-app-development/android-runtime-how-dalvik-and-art-work.md)
 - [Machine Learning](software-engineering/machine-learning/README.md)
   - [openmv.io](software-engineering/machine-learning/openmv.io.md)
   - [Google MLKit](software-engineering/machine-learning/google-mlkit/README.md)

--- a/software-engineering/android-app-development/android-runtime-how-dalvik-and-art-work.md
+++ b/software-engineering/android-app-development/android-runtime-how-dalvik-and-art-work.md
@@ -1,0 +1,50 @@
+---
+title: Android Runtime - How Dalvik and ART Work
+description: Imported note from ProAndroidDev
+---
+
+# Android Runtime - How Dalvik and ART Work
+
+## Source
+- Type: webpage
+- Origin: https://proandroiddev.com/android-runtime-how-dalvik-and-art-work-6e57cf1c50e5
+- Author: Paulina Sadowska
+- Imported: 2026-04-20
+
+## Content
+This article explains how Android Runtime translates app bytecode (`.dex`) into CPU-executable machine code, and how compilation strategies evolved from Dalvik to ART to balance performance, RAM usage, and install/update cost.
+
+### Runtime basics
+- APKs include `.dex` bytecode for app/library logic.
+- Android Runtime compiles this bytecode to machine code at runtime or ahead of runtime depending on strategy.
+- Runtime behavior also includes memory management and garbage collection (not the focus of this article).
+
+### Dalvik era (up to Android K)
+- Dalvik emphasized low RAM usage on early devices.
+- It relied on JIT (Just-In-Time) compilation: compiling code during execution.
+- Benefit: lower memory pressure from not precompiling everything.
+- Trade-off: slower runtime performance due to on-the-fly compilation.
+
+### ART in Android L
+- ART introduced AOT (Ahead-Of-Time) compilation.
+- Code is compiled before execution, improving app runtime speed significantly.
+- Trade-offs:
+  - higher storage/RAM cost,
+  - slower app installation and system updates due to broad precompilation.
+
+### Android N: profile-guided hybrid model
+- Android Runtime reintroduced JIT plus profile-guided compilation.
+- Frequently executed ("hot") methods are identified and precompiled/cached.
+- This hybrid approach improves hot-path performance while avoiding full precompile overhead.
+- Precompilation is scheduled during idle/charging windows to reduce user impact.
+
+### Android P: cloud/common profiles
+- Google introduced cloud-distributed common profiles for new installs.
+- A "common core profile" precompiles methods/classes commonly used by most users.
+- Device-specific profiling still continues after install for user-specific optimization.
+
+## Key Takeaways
+- Dalvik prioritized RAM efficiency with JIT; ART initially prioritized execution speed with AOT.
+- Modern Android Runtime uses a hybrid JIT + profile-guided model for better real-world efficiency.
+- Cloud/common profiles improve first-run experience by pre-optimizing frequently used code paths.
+- Runtime compilation strategy is a major factor in startup speed, install cost, and overall UX.


### PR DESCRIPTION
## Summary
- import and structure notes from the ProAndroidDev article on Android Runtime
- cover Dalvik JIT, ART AOT, profile-guided compilation, and cloud profiles
- add the document to Android App Development and update `SUMMARY.md`

## Test plan
- [x] Confirm markdown file exists at `software-engineering/android-app-development/android-runtime-how-dalvik-and-art-work.md`
- [x] Verify source metadata and author attribution are present
- [x] Verify `SUMMARY.md` entry was added under Android App Development

Made with [Cursor](https://cursor.com)