### PR TITLE
fix(docs): switch VitePress base for custom domain

### DIFF
--- a/.github/DOCUMENTATION-STYLE-GUIDE.md
+++ b/.github/DOCUMENTATION-STYLE-GUIDE.md
@@ -47,4 +47,4 @@ This repository was imported from GitBook. For **VitePress / GitHub Pages**, use
 - Install Node.js 20+, then `npm ci`, `npm run docs:dev` (preview) or `npm run docs:build` (static output in `.vitepress/dist/`).
 - Navigation is defined in [SUMMARY.md](../SUMMARY.md); run `npm run docs:gen-sidebar` (or `docs:prep`) to regenerate [`.vitepress/sidebar.generated.mjs`](../.vitepress/sidebar.generated.mjs) after editing `SUMMARY.md`.
 - GitHub Actions ([`.github/workflows/vitepress.yml`](../.github/workflows/vitepress.yml)) builds and publishes to the `gh-pages` branch on pushes to `main`/`master`.
-- Site `base` is set in [`.vitepress/config.ts`](../.vitepress/config.ts) (`/gitbook-personnal-docs/`). The public URL is typically `https://<user>.github.io/<repo>/`.
+- Site `base` is set in [`.vitepress/config.ts`](../.vitepress/config.ts) (`/` for the custom domain). The public URL is [https://docs.f1y.ing/](https://docs.f1y.ing/).

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -5,7 +5,8 @@ export default defineConfig({
   title: "Personal Documentation",
   description:
     "Software engineering, hardware, robotics, GIS, and related notes.",
-  base: "/gitbook-personnal-docs/",
+  // Custom domain serves docs at the root.
+  base: "/",
   vite: {
     // GitBook assets: mixed-case extensions and extensionless filenames under .gitbook/assets/
     assetsInclude: [

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ See [.github/DOCUMENTATION-STYLE-GUIDE.md](.github/DOCUMENTATION-STYLE-GUIDE.md)
 ## Published site (VitePress on GitHub Pages)
 
 - **Prerequisites**: [Node.js](https://nodejs.org/) 20+ and `npm ci`.
-- **Local preview**: `npm run docs:dev` (runs `README.md` → `index.md` sync, regenerates the sidebar from `SUMMARY.md`, then starts VitePress). Open the printed URL (default port **5173**), with base path **`/gitbook-personnal-docs/`**.
+- **Local preview**: `npm run docs:dev` (runs `README.md` → `index.md` sync, regenerates the sidebar from `SUMMARY.md`, then starts VitePress). Open the printed URL (default port **5173**), served at the root path **`/`**.
 - **Production build**: `npm run docs:build` writes to [`.vitepress/dist/`](.vitepress/dist/) (gitignored).
-- **GitHub Pages**: pushes to `main` or `master` run [`.github/workflows/vitepress.yml`](.github/workflows/vitepress.yml), which deploys **`.vitepress/dist`** to the **`gh-pages`** branch. In **Settings → Pages**, use branch **`gh-pages`** at **`/`**. The site URL is [https://devinnorgarb.github.io/gitbook-personnal-docs/](https://devinnorgarb.github.io/gitbook-personnal-docs/) (include the repo path; adjust the owner name on forks).
+- **GitHub Pages**: pushes to `main` or `master` run [`.github/workflows/vitepress.yml`](.github/workflows/vitepress.yml), which deploys **`.vitepress/dist`** to the **`gh-pages`** branch. In **Settings → Pages**, use branch **`gh-pages`** at **`/`**. The primary site URL is [https://docs.f1y.ing/](https://docs.f1y.ing/) (if no custom domain is configured, use the repository path URL for the Pages host).
 
 **Audit reports**: `npm run docs:audit` writes `docs-audit-report.json` and `docs-audit-report.md` (gitignored); CI uploads them as a workflow artifact.
 


### PR DESCRIPTION
## Summary
- switch VitePress `base` from `/gitbook-personnal-docs/` to `/` so assets resolve correctly on `https://docs.f1y.ing/`
- update publishing docs in `README.md` and `.github/DOCUMENTATION-STYLE-GUIDE.md` to reflect the custom-domain root URL

## Test plan
- [x] Run `npm run docs:build`
- [x] Confirm build completes successfully
- [ ] Verify layout/assets render correctly on `https://docs.f1y.ing/` after deployment