### PR TITLE
chore(migration): archive legacy tooling and fix snippet fences

### DIFF
--- a/.gitbook/assets/Makefile
+++ b/.gitbook/assets/Makefile
@@ -1,6 +1,0 @@
-.PHONY: html
-
-html:
-	python -m markdown README.md > html/README.html
-	python -m markdown python.md > html/python.html
-	python -m markdown web_service.md > html/web_service.html

--- a/.github/DOCUMENTATION-STYLE-GUIDE.md
+++ b/.github/DOCUMENTATION-STYLE-GUIDE.md
@@ -38,7 +38,7 @@ description: Optional one-line summary (for tooltips/search)
 
 This repository was imported from GitBook. For **VitePress / GitHub Pages**, use portable markdown instead of GitBook tags:
 
-- **File / PDF downloads**: `[filename](relative-or-asset-path)` (see [`scripts/convert_gitbook_tags.py`](../scripts/convert_gitbook_tags.py) for historical conversions).
+- **File / PDF downloads**: `[filename](relative-or-asset-path)` (see [`scripts/archive/`](../scripts/archive/) for historical conversions).
 - **Callouts**: use blockquotes with a bold label (for example `> **Note**`).
 - **Embeds**: use a normal markdown link or angle-bracket URL `<https://...>`.
 

--- a/.github/workflows/vitepress.yml
+++ b/.github/workflows/vitepress.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: vitepress-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     "README.md",
     "SUMMARY.md",
     "DOCUMENTATION-REFACTORING-REPORT.md",
+    "ARCHITECTURE-REVIEW.md",
     "docs-audit-report.md",
     "CONTRIBUTING.md",
     ".cursor/**",

--- a/ARCHITECTURE-REVIEW.md
+++ b/ARCHITECTURE-REVIEW.md
@@ -1,0 +1,219 @@
+# Architecture Deepening Opportunities — gitbook-personnal-docs
+
+**Date:** 2026-06-06
+**Scope:** Repository architecture review (improve-codebase-architecture skill)
+
+## Context
+
+This repo is a **documentation knowledge base** (~500 markdown pages) with a thin **VitePress publishing pipeline** in `scripts/`. There is no `CONTEXT.md` or ADRs yet — domain boundaries live in `SUMMARY.md` section headers and top-level folders (Software Engineering, OBD2, Robotics, GIS, etc.).
+
+Executable logic is concentrated in modules wired through `package.json`:
+
+| npm script | Module |
+|------------|--------|
+| `docs:gen-index` | `scripts/sync-index-from-readme.mjs` |
+| `docs:gen-sidebar` | `scripts/summary-to-vitepress-sidebar.mjs` |
+| `docs:prep` | index + sidebar generation |
+| `docs:dev` / `docs:build` | VitePress via `.vitepress/config.ts` |
+| `docs:audit` | `scripts/docs-audit.mjs` |
+
+Additional tooling (not wired to npm): `scripts/convert_gitbook_tags.py`, `refactor_md.py` (orphan at repo root).
+
+The deepest friction is not missing abstractions in application code — it is **duplicate content, inconsistent asset layout, legacy migration debris, and untested doc tooling** sitting on top of a large heterogeneous knowledge graph.
+
+---
+
+## 1. Doc publishing pipeline
+
+**Files:** `scripts/summary-to-vitepress-sidebar.mjs`, `scripts/docs-audit.mjs`, `scripts/convert_gitbook_tags.py`, `refactor_md.py`, `.vitepress/config.ts`, `.vitepress/sidebar.generated.mjs`
+
+**Problem:** Three separate modules each re-implement SUMMARY parsing, markdown walking, and frontmatter stripping. `refactor_md.py` (~310 lines) sits at repo root, unwired to `package.json` or CI, and overlaps with `convert_gitbook_tags.py` on fence normalization and heading cleanup. The sidebar generator encodes VitePress routing rules (`README` → `/path/README`, root → `/`) that are duplicated only in comments — coupled to `cleanUrls: false` in config. The 2250-line `sidebar.generated.mjs` is a committed artifact that can drift from `SUMMARY.md`.
+
+**Solution:** Consolidate into a single **Publishing** module family: shared markdown/SUMMARY parsing utilities, one migration/archive path for tag conversion, and explicit generation of sidebar output (or CI enforcement that it matches). Delete or relocate `refactor_md.py`.
+
+**Benefits:**
+
+- **Locality** for navigation rules and markdown transforms — fix a README-link bug once, not in three files.
+- **Leverage** for callers: one `docs:prep` seam exercises the whole publish path.
+- Tests can target the shared parser interface with SUMMARY fixtures instead of regex archaeology across three scripts.
+
+**Status:** Not started
+
+---
+
+## 2. Canonical runbook pattern (operational procedures)
+
+**Files:**
+
+- `snippets-and-scripts/scripts/run-docker-commands-without-needing-sudo.md`
+- `snippets-and-scripts/scripts/run-docker-without-needing-sudo.md` (orphan duplicate)
+- `snippets-and-scripts/install-scripts/install-docker-and-docker-compose/docker-without-root-privileges.md`
+- `software-engineering/containerisation/docker/run-docker-without-sudo.md`
+
+**Problem:** The same procedure — running Docker without sudo — exists in four places with near-identical content. Only one is in `SUMMARY.md`; `run-docker-without-needing-sudo.md` appears to be an orphan twin. Knowledge about *when* to use which variant is spread across callers (readers), not behind one interface.
+
+**Solution:** One canonical **Runbook** page per procedure. Short variants become links or callout sections pointing to it. Delete orphan duplicates.
+
+**Benefits:**
+
+- **Locality** — update the `usermod`/`docker` group steps once.
+- **Leverage** — every install guide and snippet page inherits the same truth.
+- Tests (or audit rules) can assert "at most one canonical page per procedure ID" instead of manual dedup hunts.
+
+**Status:** Not started
+
+---
+
+## 3. Asset store strategy
+
+**Files:** `.gitbook/assets/` (~1 GB), `microcontrollers-and-socs/assets/`, `microcontrollers-and-socs/esp32/assets/`, `.vitepress/config.ts` (`assetsInclude` workaround)
+
+**Problem:** `.gitbook/assets/` is a junk drawer: images, PDFs, extensionless HTML exports (`code`, `workflow`), vendored READMEs, EDA files, and unreferenced C source (`sensor_data_for_vehicle_interior.c`). VitePress config must special-case its shape (`assetsInclude` for mixed-case and extensionless files). Newer content (ESP32 RF layout, MQ135 sensor) uses a cleaner per-topic `assets/<source-slug>/` pattern — two strategies coexist with no documented rule.
+
+**Solution:** Define an **Asset** convention: topic-local `assets/` with typed filenames; migrate high-traffic references off `.gitbook/assets/`; quarantine or delete unreferenced blobs. Collapse `assetsInclude` workarounds as the legacy store shrinks.
+
+**Benefits:**
+
+- **Locality** for "where does this image live?" — one rule, not three directory strategies.
+- **Leverage** for the publishing module: asset resolution becomes predictable, so link/image audit in `docs-audit.mjs` can be stricter.
+- Fewer VitePress config exceptions.
+
+**Status:** Not started
+
+---
+
+## 4. Navigation seam (SUMMARY ↔ sidebar ↔ routes)
+
+**Files:** `SUMMARY.md`, `scripts/summary-to-vitepress-sidebar.mjs`, `.vitepress/sidebar.generated.mjs`, `.vitepress/config.ts`
+
+**Problem:** `SUMMARY.md` is the sole source of truth for structure, but the generated sidebar is a second artifact committed to git. The generator's `mdToLink()` function bakes in VitePress-specific routing invariants that aren't validated — a SUMMARY edit can produce a sidebar entry that 404s under `cleanUrls: false`. No test fixtures cover nested lists, `##` section breaks, or README deduplication.
+
+**Solution:** Deepen the **Navigation** module: either generate sidebar only at build time (drop committed artifact), or add a `docs:check-sidebar` that fails CI on drift. Extract routing rules into a tested, documented interface shared with `docs-audit.mjs` orphan detection.
+
+**Benefits:**
+
+- **Locality** for "why does this link 404?" — one module owns SUMMARY → URL mapping.
+- **Leverage** for contributors: edit `SUMMARY.md`, run one command, trust the output.
+- Regression tests on the interface catch nested-list edge cases before deploy.
+
+**Status:** Not started
+
+---
+
+## 5. Operations docs topology (`readme/` vs `snippets-and-scripts/`)
+
+**Files:** `readme/` (backups, Influx scripts), `snippets-and-scripts/scripts/`, `snippets-and-scripts/install-scripts/`, `SUMMARY.md` "Start" section
+
+**Problem:** Operational content is split across `readme/` (home-section backups, disk usage) and `snippets-and-scripts/` (install runbooks, one-liners) with overlapping purpose but different folder conventions. The `readme/` vs `README.md` naming collision is a recurring footgun (section landing pages vs home operational docs).
+
+**Solution:** Unify under one **Operations** subtree in the Start section — either fold `readme/` into `snippets-and-scripts/` or vice versa, with a clear rule: `README.md` = section landing, `readme/` prefix = deprecated/relocated.
+
+**Benefits:**
+
+- **Locality** for "where do I put a new backup script?"
+- **Leverage** for navigation: one place to search.
+- Audit hotspots for structural mismatches shrink.
+
+**Status:** Not started
+
+---
+
+## 6. Legacy migration debris
+
+**Files:** `book/` (gitignored, ~1.7 GB mdBook output on disk), `refactor_md.py`, `scripts/convert_gitbook_tags.py`, `.gitbook/assets/Makefile`, broken fences in `snippets-and-scripts/scripts/README.md`
+
+**Problem:** VitePress migration is source-complete but disk- and content-incomplete. Local `book/` still contains mdBook HTML (generated output, not custom tools). `refactor_md.py` is a manual footgun. GitBook fence pollution (`` ```php `` on shell blocks) and broken code fences remain across install scripts.
+
+**Solution:** Purge local `book/`, archive or delete unwired migration tools, run a one-shot **Migration cleanup** pass (fence normalization via the consolidated publishing module, broken-fence repair). Mark `convert_gitbook_tags.py` as archived once satisfied.
+
+**Benefits:**
+
+- **Locality** for "is this file still relevant?" — no orphan scripts at repo root.
+- **Leverage** for tooling: syntax highlighting and any future fence-aware audit work correctly.
+- Removes ~1.7 GB of misleading local state.
+
+**Status:** Not started
+
+---
+
+## 7. Section topology mismatches
+
+**Files:** `android-dev/` (4 pages at repo root), `software-engineering/android-app-development/` (canonical section), `misc/tutorials/.../install-k3s/` (mixed-topic junk drawer), `android-dev/copy-apk-file-usiung-adb.md` (typo orphan)
+
+**Problem:** `android-dev/` lives at repo root while `SUMMARY.md` nests it under Software Engineering — flagged as a hotspot in `docs-audit.mjs` but not fixed. The K3s tutorial path contains unrelated topics (AI, GIS, Lando, Arduino) under one folder. Typo-duplicates have no inbound links.
+
+**Solution:** Fold `android-dev/` into `software-engineering/android-app-development/`, split the K3s junk drawer into topic folders, delete typo orphans. Optionally encode allowed path ↔ section mappings in audit config instead of hard-coded `HOTSPOTS`.
+
+**Benefits:**
+
+- **Locality** for domain concepts — Android content lives where the section says it lives.
+- **Leverage** for AI navigation and human browsing: folder path predicts SUMMARY section.
+- Audit becomes config-driven rather than a growing inline array.
+
+**Status:** Not started
+
+---
+
+## 8. Doc audit as a gate (not just a report)
+
+**Files:** `scripts/docs-audit.mjs`, `.github/workflows/vitepress.yml`, `docs-audit-report.{json,md}`
+
+**Problem:** Audit runs in CI and uploads reports, but doesn't fail the build. Thresholds (`THIN_WORDS = 60`) and structural rules (`HOTSPOTS` array) are hard-coded. No golden-file tests for link/image parsing.
+
+**Solution:** Deepen the **Audit** module interface: `--fail-on` flags for thin content, orphans, broken local images; external `audit.config.json` for hotspots and thresholds. Add fixture tests for the markdown parser.
+
+**Benefits:**
+
+- **Locality** for quality rules — change a threshold in config, not in implementation.
+- **Leverage** for CI: the same interface that generates reports can gate merges.
+- Tests survive refactors because they target the audit interface, not internal regex details.
+
+**Status:** Not started
+
+---
+
+## Skipped for now
+
+| Item | Reason |
+|------|--------|
+| Extract markdown code blocks into runnable `bin/` scripts | Repo value is copy-paste runbooks, not a CLI library. Converting fences is hygiene, not architecture. |
+| `sync-index-from-readme.mjs` | Fails the deletion test (pure pass-through). Not worth deepening unless folded into a richer `docs:prep` orchestrator. |
+
+---
+
+## Module complexity summary
+
+| Module | Interface complexity | Implementation complexity | Verdict |
+|--------|---------------------|---------------------------|---------|
+| `sync-index-from-readme.mjs` | 1 npm script | 1 `copyFileSync` | Pass-through |
+| `summary-to-vitepress-sidebar.mjs` | 1 npm script | ~125 lines parsing logic | Real module — needs tests |
+| `docs-audit.mjs` | 1 npm script | ~255 lines | Real module — needs tests + config extraction |
+| `convert_gitbook_tags.py` | CLI, no npm hook | ~230 lines regex | Migration tool — archive or test |
+| `refactor_md.py` | none (unwired) | ~310 lines | Dead weight / risk |
+| `snippets-and-scripts/*` | markdown pages | prose + code blocks | Docs, not software modules |
+| `.gitbook/assets/Makefile` | `make html` | 3 lines | Broken orphan |
+
+---
+
+## Domain map (from SUMMARY.md)
+
+| Section | Domain focus |
+|---------|--------------|
+| Start | Home, backups, install scripts, operational snippets |
+| Software Engineering | WASM, automation, Android, ML, PHP/Laravel, containers, K8s, networking, Linux, Grafana |
+| OBD2 | Vehicle diagnostics, CAN bus, car hacking, simulators, OVMS, Traccar |
+| Robotics | SITL, ROS, ArduSub, PixHawk, MAVLink, sensors, firmware |
+| MicroControllers & SoCs | Raspberry Pi, Arduino, ESP32, nRF24, GPS shields |
+| Self-Hosting | Sentry, hardware |
+| GIS | Geocoding, Tile38, Deck.gl, Mapbox, Pelias, spatial stack |
+| Pen Testing | Drones, automotive, decompilers, Kali, captive portals |
+| Drones | DashWare, DJI Android SDK docs |
+| Software Defined Radio | Open RAN, RTL-SDR |
+
+Cross-cutting concepts: **GitBook → VitePress migration**, **self-hosted infra**, **vehicle/robotics embedded systems**, **GIS/spatial data**.
+
+---
+
+## Next steps
+
+Pick one or more candidates (e.g. "1 + 4" for the full publishing/navigation seam) to walk the design tree: constraints, dependencies, what sits behind the seam, and what tests survive. New domain terms crystallized during that conversation should be added to `CONTEXT.md`.

--- a/ARCHITECTURE-REVIEW.md
+++ b/ARCHITECTURE-REVIEW.md
@@ -17,7 +17,7 @@ Executable logic is concentrated in modules wired through `package.json`:
 | `docs:dev` / `docs:build` | VitePress via `.vitepress/config.ts` |
 | `docs:audit` | `scripts/docs-audit.mjs` |
 
-Additional tooling (not wired to npm): `scripts/convert_gitbook_tags.py`, `refactor_md.py` (orphan at repo root).
+Additional tooling (archived, not wired to npm): `scripts/archive/convert_gitbook_tags.py`, `scripts/archive/refactor_md.py`.
 
 The deepest friction is not missing abstractions in application code — it is **duplicate content, inconsistent asset layout, legacy migration debris, and untested doc tooling** sitting on top of a large heterogeneous knowledge graph.
 
@@ -132,7 +132,15 @@ The deepest friction is not missing abstractions in application code — it is *
 - **Leverage** for tooling: syntax highlighting and any future fence-aware audit work correctly.
 - Removes ~1.7 GB of misleading local state.
 
-**Status:** Not started
+**Status:** Complete — PR [#26](https://github.com/DevinNorgarb/gitbook-personnal-docs/pull/26)
+
+**Done:**
+
+- Archived `refactor_md.py` and `convert_gitbook_tags.py` under `scripts/archive/` with README
+- Removed orphan `.gitbook/assets/Makefile` via git
+- Fixed broken code fences in `snippets-and-scripts/scripts/README.md`
+- Normalized `` ```php `` → `` ```console `` in `snippets-and-scripts/` install/runbook pages
+- Documented that gitignored `book/` is safe to delete locally
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ See [.github/DOCUMENTATION-STYLE-GUIDE.md](.github/DOCUMENTATION-STYLE-GUIDE.md)
 
 **Audit reports**: `npm run docs:audit` writes `docs-audit-report.json` and `docs-audit-report.md` (gitignored); CI uploads them as a workflow artifact.
 
-GitBook-only constructs in markdown were converted for portable rendering; see [`scripts/convert_gitbook_tags.py`](scripts/convert_gitbook_tags.py) if you need similar conversions for new imports.
+GitBook-only constructs in markdown were converted for portable rendering; see [`scripts/archive/`](scripts/archive/) for archived migration tooling if you need similar conversions for new imports.

--- a/scripts/archive/README.md
+++ b/scripts/archive/README.md
@@ -1,0 +1,17 @@
+# Archived migration tooling
+
+One-shot scripts used during the GitBook → VitePress migration. Kept for reference and recoverability in git; not wired to `package.json` or CI.
+
+| Script | Purpose |
+|--------|---------|
+| [`convert_gitbook_tags.py`](convert_gitbook_tags.py) | Convert `{% embed %}`, hints, and proxy images to portable markdown |
+| [`refactor_md.py`](refactor_md.py) | Bulk markdown hygiene (headings, fences, list markers) |
+
+Run from repo root, for example:
+
+```bash
+python3 scripts/archive/convert_gitbook_tags.py
+python3 scripts/archive/refactor_md.py
+```
+
+**Local mdBook output:** The gitignored `book/` directory (legacy mdBook HTML) is safe to delete locally. It is not published; VitePress excludes it via `srcExclude`.

--- a/scripts/archive/convert_gitbook_tags.py
+++ b/scripts/archive/convert_gitbook_tags.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Convert GitBook-specific markdown tags to portable markdown for mdBook / GitHub Pages.
-Run from repo root: python3 scripts/convert_gitbook_tags.py
+Run from repo root: python3 scripts/archive/convert_gitbook_tags.py
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 from urllib.parse import unquote
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 SKIP_PARTS = frozenset({".cursor", "book", ".git"})
 
 

--- a/scripts/archive/refactor_md.py
+++ b/scripts/archive/refactor_md.py
@@ -15,7 +15,7 @@ import re
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(__file__).resolve().parents[2]
 SKIP_DIRS = {".git", "node_modules", "__pycache__"}
 
 # Language hints for code blocks (keyword -> lang)

--- a/scripts/docs-audit.mjs
+++ b/scripts/docs-audit.mjs
@@ -146,6 +146,7 @@ function main() {
     if (rel.startsWith(".github/")) continue;
     if (rel === "SUMMARY.md" || rel === "CONTRIBUTING.md") continue;
     if (rel === "DOCUMENTATION-REFACTORING-REPORT.md") continue;
+    if (rel === "ARCHITECTURE-REVIEW.md") continue;
     if (rel === "docs-audit-report.md") continue;
     if (rel === "index.md") continue;
 

--- a/snippets-and-scripts/install-scripts/esp-idf.md
+++ b/snippets-and-scripts/install-scripts/esp-idf.md
@@ -28,12 +28,12 @@ To compile using ESP-IDF, you need to get the following packages. The command to
 
 -   Ubuntu and Debian:
 
-```php
+```console
     sudo apt-get install git wget flex bison gperf python3 python3-pip python3-venv cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0
-```php
+```console
 -   CentOS 7 & 8:
 
-```php
+```console
     sudo yum -y update && sudo yum install git wget flex bison gperf python3 cmake ninja-build ccache dfu-util libusbx
 ```
 
@@ -41,7 +41,7 @@ CentOS 7 is still supported but CentOS version 8 is recommended for a better use
 
 -   Arch:
 
-```php
+```console
     sudo pacman -S --needed gcc git make flex bison gperf python cmake ninja ccache dfu-util libusb
 ```
 
@@ -57,14 +57,14 @@ ESP-IDF uses the version of Python installed by default on macOS.
 - Install CMake & Ninja build:
   -   If you have [Homebrew](https://brew.sh/), you can run:
 
-```php
+```console
       brew install cmake ninja dfu-util
-```php
+```console
   -   If you have [MacPorts](https://www.macports.org/install.php), you can run:
 
-```php
+```console
       sudo port install cmake ninja dfu-util
-```php
+```console
   - Otherwise, consult the [CMake](https://cmake.org/) and [Ninja](https://ninja-build.org/) home pages for macOS installation downloads.
 - It is strongly recommended to also install [ccache](https://ccache.dev/) for faster builds. If you have [Homebrew](https://brew.sh/), this can be done via `brew install ccache` or `sudo port install ccache` on [MacPorts](https://www.macports.org/install.php).
 
@@ -72,7 +72,7 @@ Note
 
 If an error like this is shown during any step:
 
-```php
+```console
 xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun
 ```
 
@@ -89,13 +89,13 @@ ERROR: tool xtensa-esp32-elf has no installed versions. Please run 'install.sh' 
 
 or:
 
-```php
+```console
 zsh: bad CPU type in executable: ~/.espressif/tools/xtensa-esp32-elf/esp-2021r2-patch3-8.4.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-gcc
 ```
 
 Then you need to install Apple Rosetta 2 by running
 
-```php
+```console
 /usr/sbin/softwareupdate --install-rosetta --agree-to-license
 ```
 
@@ -103,13 +103,13 @@ Then you need to install Apple Rosetta 2 by running
 
 Based on macOS [Catalina 10.15 release notes](https://developer.apple.com/documentation/macos-release-notes/macos-catalina-10\_15-release-notes), use of Python 2.7 is not recommended and Python 2.7 is not included by default in future versions of macOS. Check what Python you currently have:
 
-```php
+```console
 python --version
 ```
 
 If the output is like `Python 2.7.17`, your default interpreter is Python 2.7. If so, also check if Python 3 is not already installed on your computer:
 
-```php
+```console
 python3 --version
 ```
 
@@ -136,7 +136,7 @@ To get ESP-IDF, navigate to your installation directory and clone the repository
 
 Open Terminal, and run the following commands:
 
-```php
+```console
 mkdir -p ~/esp
 cd ~/esp
 git clone --recursive https://github.com/espressif/esp-idf.git
@@ -238,13 +238,13 @@ The installed tools are not yet added to the PATH environment variable. To make 
 
 In the terminal where you are going to use ESP-IDF, run:
 
-```php
+```console
 . $HOME/esp/esp-idf/export.sh
 ```
 
 or for fish (supported only since fish version 3.0.0):
 
-```php
+```console
 . $HOME/esp/esp-idf/export.fish
 ```
 
@@ -345,7 +345,7 @@ idf.py build
 
 This command compiles the application and all ESP-IDF components, then it generates the bootloader, partition table, and application binaries.
 
-```php
+```console
 $ idf.py build
 Running cmake in directory /path/to/hello_world/build
 Executing "cmake -G Ninja --warn-uninitialized /path/to/hello_world"...
@@ -437,7 +437,7 @@ To check if “hello\_world” is indeed running, type `idf.py -p PORT monitor` 
 
 This command launches the [IDF Monitor](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-monitor.html) application:
 
-```php
+```console
 $ idf.py -p <PORT> monitor
 Running idf_monitor in directory [...]/esp/hello_world/build
 Executing "python [...]/esp-idf/tools/idf_monitor.py -b 115200 [...]/esp/hello_world/build/hello_world.elf"...
@@ -452,7 +452,7 @@ ets Jun  8 2016 00:22:57
 
 After startup and diagnostic logs scroll up, you should see “Hello world!” printed out by the application.
 
-```php
+```console
     ...
     Hello world!
     Restarting in 10 seconds...

--- a/snippets-and-scripts/install-scripts/httpie.md
+++ b/snippets-and-scripts/install-scripts/httpie.md
@@ -202,7 +202,7 @@ If you want to try out the latest version of HTTPie that hasn't been officially 
 
 You can use the following command to install the development version of HTTPie on Linux, macOS, Windows, or FreeBSD operating systems. With this command, the code present in the `master` branch is downloaded and installed using `pip`.
 
-```php
+```console
 $ python -m pip install --upgrade https://github.com/httpie/cli/archive/master.tar.gz
 ```
 
@@ -210,21 +210,21 @@ There are other ways to install the development version of HTTPie on macOS and L
 
 You can install it using Homebrew by running the following commands:
 
-```php
+```console
 $ brew uninstall --force httpie
 $ brew install --HEAD httpie
 ```
 
 You can install it using Snapcraft by running the following commands:
 
-```php
+```console
 $ snap remove httpie
 $ snap install httpie --edge
 ```
 
 To verify the installation, you can compare the [version identifier on GitHub](https://github.com/httpie/cli/blob/master/httpie/\_\_init\_\_.py#L6) with the one available on your machine. You can check the version of HTTPie on your machine by using the command `http --version`.
 
-```php
+```console
 $ http --version
 ## 3.X.X.dev0
 ```

--- a/snippets-and-scripts/install-scripts/install-docker-and-docker-compose/README.md
+++ b/snippets-and-scripts/install-scripts/install-docker-and-docker-compose/README.md
@@ -40,7 +40,7 @@ Docker Engine is supported on `x86_64` (or `amd64`), `armhf`, `arm64`, and `s390
 
 Older versions of Docker were called `docker`, `docker.io`, or `docker-engine`. If these are installed, uninstall them:
 
-```php
+```console
 $ sudo apt-get remove docker docker-engine docker.io containerd runc
 ```
 
@@ -70,7 +70,7 @@ Before you install Docker Engine for the first time on a new host machine, you n
 
 1.  Update the `apt` package index and install packages to allow `apt` to use a repository over HTTPS:
 
-```php
+```console
     $ sudo apt-get update
 
     $ sudo apt-get install \
@@ -78,12 +78,12 @@ Before you install Docker Engine for the first time on a new host machine, you n
         curl \
         gnupg \
         lsb-release
-```php
+```console
 2.  Add Docker’s official GPG key:
 
-```php
+```console
     $ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-```php
+```console
 3.  Use the following command to set up the **stable** repository. To add the **nightly** or **test** repository, add the word `nightly` or `test` (or both) after the word `stable` in the commands below. Learn about **nightly** and **test** channels.
 
 ```bash
@@ -119,12 +119,12 @@ Before you install Docker Engine for the first time on a new host machine, you n
 
     b. Install a specific version using the version string from the second column, for example, `5:18.09.1~3-0~ubuntu-xenial`.
 
-```php
+```console
     $ sudo apt-get install docker-ce=<VERSION_STRING> docker-ce-cli=<VERSION_STRING> containerd.io
-```php
+```console
 3.  Verify that Docker Engine is installed correctly by running the `hello-world` image.
 
-```php
+```console
     $ sudo docker run hello-world
 ```
 
@@ -147,14 +147,14 @@ If you cannot use Docker’s repository to install Docker Engine, you can downlo
     > To install a **nightly** or **test** (pre-release) package, change the word `stable` in the above URL to `nightly` or `test`. Learn about **nightly** and **test** channels.
 2.  Install Docker Engine, changing the path below to the path where you downloaded the Docker package.
 
-```php
+```console
     $ sudo dpkg -i /path/to/package.deb
 ```
 
     The Docker daemon starts automatically.
 3.  Verify that Docker Engine is installed correctly by running the `hello-world` image.
 
-```php
+```console
     $ sudo docker run hello-world
 ```
 
@@ -189,7 +189,7 @@ Always examine scripts downloaded from the internet before running them locally.
 
 This example downloads the script from [get.docker.com](https://get.docker.com/) and runs it to install the latest stable release of Docker on Linux:
 
-```php
+```console
 $ curl -fsSL https://get.docker.com -o get-docker.sh
 $ sudo sh get-docker.sh
 Executing docker install script, commit: 7cae5f8b0decc17d6571f9f52eb840fbc13b2737
@@ -208,7 +208,7 @@ Docker also provides a convenience script at [test.docker.com](https://test.dock
 
 To install the latest version of Docker on Linux from the “test” channel, run:
 
-```php
+```console
 $ curl -fsSL https://test.docker.com -o test-docker.sh
 $ sudo sh test-docker.sh
 <...>

--- a/snippets-and-scripts/install-scripts/pihole.md
+++ b/snippets-and-scripts/install-scripts/pihole.md
@@ -22,7 +22,7 @@ If you would prefer to review the code before installation, we provide these alt
 
 ### Alternative 1: Clone our repository and run[¶](https://docs.pi-hole.net/main/basic-install/#alternative-1-clone-our-repository-and-run) <a href="#alternative-1-clone-our-repository-and-run" id="alternative-1-clone-our-repository-and-run"></a>
 
-```php
+```console
 git clone --depth 1 https://github.com/pi-hole/pi-hole.git Pi-hole
 cd "Pi-hole/automated install/"
 sudo bash basic-install.sh
@@ -30,7 +30,7 @@ sudo bash basic-install.sh
 
 #### Alternative 2: Manually download the installer and run[¶](https://docs.pi-hole.net/main/basic-install/#alternative-2-manually-download-the-installer-and-run) <a href="#alternative-2-manually-download-the-installer-and-run" id="alternative-2-manually-download-the-installer-and-run"></a>
 
-```php
+```console
 wget -O basic-install.sh https://install.pi-hole.net
 sudo bash basic-install.sh
 ```

--- a/snippets-and-scripts/install-scripts/yt-dlp.md
+++ b/snippets-and-scripts/install-scripts/yt-dlp.md
@@ -21,19 +21,19 @@ sudo curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o
 sudo chmod a+rx /usr/local/bin/yt-dlp  # Make executable
 ```
 
-```php
+```console
 sudo wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/local/bin/yt-dlp
 sudo chmod a+rx /usr/local/bin/yt-dlp  # Make executable
 ```
 
-```php
+```console
 sudo aria2c https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp --dir /usr/local/bin -o yt-dlp
 sudo chmod a+rx /usr/local/bin/yt-dlp  # Make executable
 ```
 
 To update, run:
 
-```php
+```console
 sudo yt-dlp -U
 ```
 
@@ -43,19 +43,19 @@ To use shell completion (autocomplete), look for the completion files in the [so
 
 You can install the [PyPI package](https://pypi.org/project/yt-dlp) with:
 
-```php
+```console
 python3 -m pip install -U yt-dlp
 ```
 
 You can install without any of the optional dependencies using:
 
-```php
+```console
 python3 -m pip install --no-deps -U yt-dlp
 ```
 
 If you want to be on the cutting edge, you can also install the master branch with:
 
-```php
+```console
 python3 -m pip install -U pip setuptools wheel
 python3 -m pip install --force-reinstall https://github.com/yt-dlp/yt-dlp/archive/master.tar.gz
 ```
@@ -148,19 +148,19 @@ doas apk -U add yt-dlp
 
 Or alternatively, without any optional dependencies:
 
-```php
+```console
 doas apk -U add yt-dlp-core
 ```
 
 yt-dlp should upgrade with your system. If you want to do that explicitly:
 
-```php
+```console
 doas apk -U upgrade yt-dlp
 ```
 
 To uninstall:
 
-```php
+```console
 doas apk del yt-dlp
 ```
 
@@ -188,19 +188,19 @@ choco install yt-dlp
 
 To update, run:
 
-```php
+```console
 choco upgrade yt-dlp
 ```
 
 #### [winget](https://docs.microsoft.com/en-us/windows/package-manager/winget/)
 
-```php
+```console
 winget install yt-dlp
 ```
 
 To update, run:
 
-```php
+```console
 winget upgrade yt-dlp
 ```
 

--- a/snippets-and-scripts/magento/magento-one-line-install.md
+++ b/snippets-and-scripts/magento/magento-one-line-install.md
@@ -83,7 +83,7 @@ After the one-liner above completes running, you should be able to access your s
 
 After the above installation is complete, run the following lines to install sample data:
 
-```php
+```console
 bin/magento sampledata:deploy
 bin/magento setup:upgrade
 ```
@@ -175,7 +175,7 @@ OpenSearch is set as the default search engine when setting up this project. Fol
 
 To update your project to the latest version of `docker-magento`, run:
 
-```php
+```console
 bin/update
 ```
 
@@ -272,13 +272,13 @@ The hostname of each service is the name of the service within the `compose.yaml
 
 To connect to the MySQL CLI tool of the Docker instance, run:
 
-```php
+```console
 bin/mysql
 ```
 
 You can use the `bin/mysql` script to import a database, for example a file stored in your local host directory at `magento.sql`:
 
-```php
+```console
 bin/mysql < magento.sql
 ```
 
@@ -355,11 +355,11 @@ Otherwise, this project now automatically sets up Xdebug support with VS Code. I
 
     - The port must be the same as the port on the xdebug.ini file.
 
-```php
+```console
       bin/cli cat /usr/local/etc/php/php.ini
 ```
 
-```php
+```console
       memory_limit = 4G
       max_execution_time = 1800
       zlib.output_compression = On
@@ -380,7 +380,7 @@ Otherwise, this project now automatically sets up Xdebug support with VS Code. I
 
     - The pathMappings should have the same folder path as the project inside the Docker container.
 
-```php
+```console
       {
           "version": "0.2.0",
           "configurations": [
@@ -396,10 +396,10 @@ Otherwise, this project now automatically sets up Xdebug support with VS Code. I
               }
           ]
       }
-```php
+```console
 5.  Run the following command in the Windows Powershell. It allows WSL through the firewall, otherwise breakpoints might not be hitten.
 
-```php
+```console
     New-NetFirewallRule -DisplayName "WSL" -Direction Inbound  -InterfaceAlias "vEthernet (WSL)"  -Action Allow
 ```
 
@@ -441,7 +441,7 @@ Copy `compose.dev-ssh.yaml` to `compose.dev.yaml` before installing Magento to t
 
 Note that you must use your IDE's SSH/SFTP functionality, otherwise changes will not be synced. To re-sync your host environment at any time, run:
 
-```php
+```console
 bin/copyfromcontainer --all
 ```
 
@@ -471,7 +471,7 @@ You must also create a new entry in your `/etc/hosts` file using the same IP:
 
 To enable Xdebug on Linux, you may also need to open port 9003 on the firewall by running:
 
-```php
+```console
 sudo iptables -A INPUT -p tcp --dport 9003 -j ACCEPT
 ```
 
@@ -479,7 +479,7 @@ You may also have to increase a virtual memory map count on the host system whic
 
 Add the following line to the `/etc/sysctl.conf` file on your host:
 
-```php
+```console
 vm.max_map_count=262144
 ```
 
@@ -487,7 +487,7 @@ vm.max_map_count=262144
 
 These docker images have built-in support for Blackfire.io. To use it, first register your server ID and token with the Blackfire agent:
 
-```php
+```console
 bin/root blackfire-agent --register --server-id={YOUR_SERVER_ID} --server-token={YOUR_SERVER_TOKEN}
 ```
 
@@ -509,7 +509,7 @@ To work with MFTF you will need to first enable the `selenium` image in the `com
 4. Run a sample test `bin/mftf run:test AdminLoginSuccessfulTest`.
 5. Update your `nginx.conf` file to allow access to the dev section with the following, before the final `deny all` section:
 
-```php
+```console
 location ~* ^/dev/tests/acceptance/utils($|/) {
     root $MAGE_ROOT;
     location ~ ^/dev/tests/acceptance/utils/command.php {

--- a/snippets-and-scripts/scripts/README.md
+++ b/snippets-and-scripts/scripts/README.md
@@ -6,22 +6,24 @@ layout: landing
 
 **Split a file in half**
 
-1.  Save the script to a file, say `split_csv.sh`:
+1. Save the script to a file, say `split_csv.sh`:
 
-    ```bash
-    #!/bin/bash
-    split -l $(( $(wc -l < "$1") / 2 + 1)) "$1" "${2:-part_}"
-```bash
-2.  Make the script executable:
+   ```bash
+   #!/bin/bash
+   split -l $(( $(wc -l < "$1") / 2 + 1)) "$1" "${2:-part_}"
+   ```
 
-    ```bash
-    chmod +x split_csv.sh
-```bash
-3.  Run the script with your CSV file and an optional prefix:
+2. Make the script executable:
 
-    ```bash
-    ./split_csv.sh test.csv myprefix_
-```
+   ```bash
+   chmod +x split_csv.sh
+   ```
+
+3. Run the script with your CSV file and an optional prefix:
+
+   ```bash
+   ./split_csv.sh test.csv myprefix_
+   ```
 
 This will split `test.csv` into two parts with filenames starting with `myprefix_`.
 
@@ -29,11 +31,11 @@ This will split `test.csv` into two parts with filenames starting with `myprefix
 
 **Resize LXD btrfs loop file in one line**
 
-```python
- grow_lxd_btrfs_file() { STORAGE_POOL="$1" ; NEW_SIZE="$2" ; STORAGE_POOL_SOURCE="$(lxc storage get "$STORAGE_POOL" source)" ; sudo truncate -s "$NEW_SIZE" "$STORAGE_POOL_SOURCE" ; STORAGE_POOL_LOOP_DEVICE="$(losetup -j "$STORAGE_POOL_SOURCE" | awk -F': ' '{print $1}' | head -1)" ; sudo losetup -c "$STORAGE_POOL_LOOP_DEVICE" ; LXD_PID=$(pgrep lxd | head -1) ; NS_MOUNT_POINT=$(sudo nsenter -t "$LXD_PID" -m -- findmnt -no target "$STORAGE_POOL_LOOP_DEVICE") ; sudo btrfs filesystem resize max "/proc/$LXD_PID/root/$NS_MOUNT_POINT" ; lxd sql global "UPDATE storage_pools_config SET value = '$NEW_SIZE' WHERE key = 'size' AND storage_pool_id IN (SELECT id FROM storage_pools WHERE name = '$STORAGE_POOL')" ; }
+```bash
+grow_lxd_btrfs_file() { STORAGE_POOL="$1" ; NEW_SIZE="$2" ; STORAGE_POOL_SOURCE="$(lxc storage get "$STORAGE_POOL" source)" ; sudo truncate -s "$NEW_SIZE" "$STORAGE_POOL_SOURCE" ; STORAGE_POOL_LOOP_DEVICE="$(losetup -j "$STORAGE_POOL_SOURCE" | awk -F': ' '{print $1}' | head -1)" ; sudo losetup -c "$STORAGE_POOL_LOOP_DEVICE" ; LXD_PID=$(pgrep lxd | head -1) ; NS_MOUNT_POINT=$(sudo nsenter -t "$LXD_PID" -m -- findmnt -no target "$STORAGE_POOL_LOOP_DEVICE") ; sudo btrfs filesystem resize max "/proc/$LXD_PID/root/$NS_MOUNT_POINT" ; lxd sql global "UPDATE storage_pools_config SET value = '$NEW_SIZE' WHERE key = 'size' AND storage_pool_id IN (SELECT id FROM storage_pools WHERE name = '$STORAGE_POOL')" ; }
 ```
 
-```python
+```bash
 grow_lxd_btrfs_file pritunl-storage-pool 50GB
 ```
 
@@ -53,7 +55,7 @@ watch "curl -s https://raw.githubusercontent.com/sivel/speedtest-cli/master/spee
 
 ***
 
-#### Top Files Sizes &#x20;
+#### Top Files Sizes
 
 ```bash
 du -a / | sort -n -r | head -n 20
@@ -63,6 +65,6 @@ du -a / | sort -n -r | head -n 20
 
 #### Top Memory Usage
 
-```
+```bash
 ps aux --sort=-%mem | head
 ```

--- a/snippets-and-scripts/scripts/run-docker-commands-without-needing-sudo.md
+++ b/snippets-and-scripts/scripts/run-docker-commands-without-needing-sudo.md
@@ -40,7 +40,7 @@ To create the `docker` group and add your user:
 
     To fix this problem, either remove the `~/.docker/` directory (it’s recreated automatically, but any custom settings are lost), or change its ownership and permissions using the following commands:
 
-```php
+```console
     $ sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
     $ sudo chmod g+rwx "$HOME/.docker" -R
 ```
@@ -49,14 +49,14 @@ To create the `docker` group and add your user:
 
 Many modern Linux distributions use [systemd](https://docs.docker.com/config/daemon/systemd/) to manage which services start when the system boots. On Debian and Ubuntu, the Docker service starts on boot by default. To automatically start Docker and containerd on boot for other Linux distributions using systemd, run the following commands:
 
-```php
+```console
 $ sudo systemctl enable docker.service
 $ sudo systemctl enable containerd.service
 ```
 
 To stop this behavior, use `disable` instead.
 
-```php
+```console
 $ sudo systemctl disable docker.service
 $ sudo systemctl disable containerd.service
 ```

--- a/snippets-and-scripts/scripts/run-docker-without-needing-sudo.md
+++ b/snippets-and-scripts/scripts/run-docker-without-needing-sudo.md
@@ -40,7 +40,7 @@ To create the `docker` group and add your user:
 
     To fix this problem, either remove the `~/.docker/` directory (it’s recreated automatically, but any custom settings are lost), or change its ownership and permissions using the following commands:
 
-```php
+```console
     $ sudo chown "$USER":"$USER" /home/"$USER"/.docker -R
     $ sudo chmod g+rwx "$HOME/.docker" -R
 ```
@@ -49,14 +49,14 @@ To create the `docker` group and add your user:
 
 Many modern Linux distributions use [systemd](https://docs.docker.com/config/daemon/systemd/) to manage which services start when the system boots. On Debian and Ubuntu, the Docker service starts on boot by default. To automatically start Docker and containerd on boot for other Linux distributions using systemd, run the following commands:
 
-```php
+```console
 $ sudo systemctl enable docker.service
 $ sudo systemctl enable containerd.service
 ```
 
 To stop this behavior, use `disable` instead.
 
-```php
+```console
 $ sudo systemctl disable docker.service
 $ sudo systemctl disable containerd.service
 ```


### PR DESCRIPTION
## Summary

- Archives `refactor_md.py` and `convert_gitbook_tags.py` under `scripts/archive/` with documentation
- Removes orphan `.gitbook/assets/Makefile` via git (recoverable from history)
- Repairs broken code fences in `snippets-and-scripts/scripts/README.md`
- Normalizes `` ```php `` → `` ```console `` in `snippets-and-scripts/` pages
- Documents that gitignored `book/` is safe to delete locally (purged ~1.7 GB on dev machine)
- Marks architecture review item #6 complete

## Test plan

- [ ] `python3 scripts/archive/convert_gitbook_tags.py --help` or dry run from repo root
- [ ] `snippets-and-scripts/scripts/README.md` fences render correctly
- [ ] `npm run docs:build` succeeds