### PR TITLE
Import linked content into empty stub pages

### DIFF
--- a/software-engineering/browsers/apis/browser-barcodedetect-api-using-image.md
+++ b/software-engineering/browsers/apis/browser-barcodedetect-api-using-image.md
@@ -1,3 +1,37 @@
+---
+title: Browser BarcodeDetect API using Image
+description: Shape Detection BarcodeDetector demo with a static image input.
+---
+
 # Browser BarcodeDetect API using Image
 
-<https://codepen.io/devromeister/pen/OJqGLjN>
+Demo of the **Barcode Detection API** (part of the [Shape Detection API](https://wicg.github.io/shape-detection-api/)) decoding barcodes from an image file in the browser — without a live camera stream.
+
+## Source
+
+- [CodePen demo](https://codepen.io/devromeister/pen/OJqGLjN) — BarcodeDetector with image input
+
+## API overview
+
+`BarcodeDetector` is available in Chromium-based browsers (check `('BarcodeDetector' in window)`). It accepts `ImageBitmap`, `Blob`, `ImageData`, or `HTMLImageElement` / `HTMLVideoElement` sources.
+
+```javascript
+const detector = new BarcodeDetector({ formats: ['qr_code', 'code_128'] });
+const barcodes = await detector.detect(imageElement);
+barcodes.forEach((code) => {
+  console.log(code.rawValue, code.format, code.boundingBox);
+});
+```
+
+Supported formats vary by browser; common values include `qr_code`, `ean_13`, `code_128`, `data_matrix`.
+
+## What the demo shows
+
+The CodePen loads a sample image, runs `BarcodeDetector.detect()`, and renders detected barcode bounds and decoded values — useful for testing detection without `getUserMedia` permissions.
+
+[Open live demo on CodePen →](https://codepen.io/devromeister/pen/OJqGLjN)
+
+## Related
+
+- [Shape Detection](./shape-detection/README.md)
+- [Browser APIs](../README.md)

--- a/software-engineering/containerisation/lxc-lxd/lxc-commands.md
+++ b/software-engineering/containerisation/lxc-lxd/lxc-commands.md
@@ -1,4 +1,35 @@
+---
+title: LXC commands
+description: Useful LXC/LXD CLI snippets for devices, ports, and config.
+---
+
 # LXC commands
 
-lxc config device remove lxd-dashboard myportname80
+Quick LXC/LXD command reference. For broader context see [LXC/LXD overview](../../containerisation/lxc-lxd/README.md).
 
+## Remove a proxy device from a container
+
+Removes a **device** (here a port forward named `myportname80`) from an instance:
+
+```bash
+lxc config device remove lxd-dashboard myportname80
+```
+
+- `lxd-dashboard` — container/instance name
+- `myportname80` — device name as shown in `lxc config device list <instance>`
+
+### Related commands
+
+```bash
+# List devices attached to an instance
+lxc config device list lxd-dashboard
+
+# Show full instance config (devices, limits, profiles)
+lxc config show lxd-dashboard
+
+# Add a proxy device (example: host 8080 → container 80)
+lxc config device add lxd-dashboard myportname80 proxy \
+  listen=tcp:0.0.0.0:8080 connect=tcp:127.0.0.1:80
+```
+
+Use `lxc config device remove` when retiring a port forward or cleaning up after a dashboard install.

--- a/software-engineering/networking/tcpdump.md
+++ b/software-engineering/networking/tcpdump.md
@@ -1,3 +1,84 @@
+---
+title: TCPDump
+description: tcpdump cheat sheet — capture, filter, and inspect network traffic.
+---
+
 # TCPDump
 
-<https://danielmiessler.com/study/tcpdump>
+`tcpdump` is a command-line packet analyzer for capturing and inspecting live network traffic. Essential for network troubleshooting and security work.
+
+## Source
+
+- [A tcpdump Tutorial with Examples](https://danielmiessler.com/study/tcpdump) — Daniel Miessler (150+ examples)
+- [tcpdump tutorial (blog)](https://danielmiessler.com/blog/tcpdump)
+
+![TCP/IP header diagram](https://danielmiessler.com/images/ip-header-2021-1024x505.png)
+
+## Basic syntax
+
+```bash
+tcpdump [options] [expression]
+```
+
+- **options** — interface, verbosity, output format, write to file
+- **expression** — filter by host, port, protocol, flags, etc.
+
+## Common captures
+
+```bash
+# List interfaces
+tcpdump -D
+
+# All traffic on an interface
+tcpdump -i eth0
+
+# Host filter
+tcpdump host 192.168.1.100
+
+# Port filter
+tcpdump port 80
+
+# Combine filters
+tcpdump host 192.168.1.100 and port 80
+tcpdump src host 192.168.1.100 and \( port 80 or port 443 \)
+
+# Protocol only
+tcpdump tcp
+tcpdump udp
+```
+
+## Useful options
+
+| Flag | Purpose |
+|------|---------|
+| `-i eth0` | Select interface (`any` for all) |
+| `-n` / `-nn` | No DNS / no port-name resolution |
+| `-c 100` | Stop after N packets |
+| `-v` / `-vv` / `-vvv` | More verbose output |
+| `-s 0` | Full packet snap length |
+| `-w file.pcap` | Write capture to file |
+| `-r file.pcap` | Read capture from file |
+| `-X` / `-XX` | Hex (+ ASCII) dump; `-XX` includes Ethernet header |
+| `-tttt` | Human-readable timestamps |
+
+## TCP flag filters
+
+```bash
+# SYN packets
+tcpdump 'tcp[13] & 2 != 0'
+
+# SYN or ACK
+tcpdump 'tcp[tcpflags] & (tcp-syn|tcp-ack) != 0'
+```
+
+## Everyday combo
+
+```bash
+tcpdump -i eth0 -nnvvS -c 50 'tcp port 443'
+```
+
+Press **Ctrl+C** to stop a live capture.
+
+## Related
+
+- [Networking section](../README.md)

--- a/software-engineering/shopify-dev/track-orders-placed-through-third-party-marketplaces.md
+++ b/software-engineering/shopify-dev/track-orders-placed-through-third-party-marketplaces.md
@@ -1,3 +1,67 @@
+---
+title: Track orders placed through third-party marketplaces
+description: Shopify GraphQL Admin API workflow for Facebook/Google marketplace orders.
+---
+
 # Track orders placed through third-party marketplaces
 
-<https://shopify.dev/docs/apps/fulfillment/order-management-apps/third-party-marketplaces>
+Orders created through third-party marketplaces (Facebook, Google, etc.) use **Shopify Payments** as the processor. Fulfillment and payment capture behave differently from other channels.
+
+## Source
+
+- [Track orders placed on other platforms](https://shopify.dev/docs/apps/fulfillment/order-management-apps/third-party-marketplaces) — Shopify developer docs
+
+## Requirements
+
+- App can make authenticated **GraphQL Admin API** requests
+- Store has unfulfilled orders to test against
+- Familiarity with `FulfillmentOrder` objects
+- [Protected customer data requirements](https://shopify.dev/docs/apps/launch/protected-customer-data) met
+
+## How marketplace orders differ
+
+| Aspect | Third-party marketplace | Other channels |
+|--------|----------------------|----------------|
+| Transaction capture | After fulfillment (marketplace initiates capture) | Often captured before fulfillment |
+| Immediate fulfillment | **No** — hold period ~30 min–24 h | Usually allowed immediately |
+| During hold | Cannot change address, edit order, issue custom refunds, or manually capture | Normal order ops |
+
+Hold period covers cancellation windows, payment authorization, and fraud review.
+
+## Recommended workflow
+
+### 1. Use fulfillment orders (not legacy Fulfillment API)
+
+As of API **2022-07**, fulfill via `FulfillmentOrder` — not legacy `Order` + `Fulfillment` objects. Migrate before **2023-07**.
+
+### 2. Identify the source channel
+
+Review fields when fetching an order:
+
+| Field | Shopify Payments | Facebook Payments |
+|-------|------------------|-------------------|
+| `displayFulfillmentStatus` | `ON_HOLD` | `UNFULFILLED` |
+| `displayFinancialStatus` | `AUTHORIZED` | `PAID` |
+| `paymentGatewayNames` | `["shopify_payments"]` | `["instagram"]` |
+
+Use `source_name` (set at order creation only) to determine channel — **not** `gateway`, which may show `shopify_payments` even for Facebook-channel orders.
+
+### 3. Decide if the order is fulfillable
+
+| Check | Value | Webhook hints |
+|-------|-------|---------------|
+| `Order.displayFinancialStatus` | `AUTHORIZED` or `PAID` | `orders/updated` |
+| `FulfillmentOrder.status` | `OPEN` | `fulfillment_orders/order_routing_complete`, `fulfillment_orders/scheduled_fulfillment_order_ready`, `fulfillment_orders/hold_released` |
+
+> **Note:** `line_items.fulfillable_quantity` is `0` when a fulfillment order is on hold — do not use it alone. Check `FulfillmentOrder.status` before creating a fulfillment after `order/create`.
+
+## Best practices
+
+- **Do not** start fulfillments solely on `orders/create`, `order_transactions/create`, or `order/paid` — use `fulfillment_orders/ready_to_fulfill` (unstable API) and inspect `FulfillmentOrder` status.
+- During the Facebook Payments → Shopify Payments transition, branch on `paymentGatewayNames` / gateway until all stores are migrated.
+- Avoid fixed hold-duration assumptions — marketplace hold times vary.
+
+## Next steps
+
+- [Manage fulfillments as an order management app](https://shopify.dev/docs/apps/fulfillment/order-management-apps)
+- [Migrate to fulfillment orders](https://shopify.dev/docs/apps/fulfillment/migrate-to-fulfillment-orders)

--- a/software-engineering/webassembly/go-and-wasm.md
+++ b/software-engineering/webassembly/go-and-wasm.md
@@ -1,3 +1,104 @@
+---
+title: Go and WASM
+description: Compile Go to WebAssembly and run it in the browser or Node.js.
+---
+
 # Go and WASM
 
-[https://github.com/golang/go/wiki/WebAssembly#executing-webassembly-with-node-js](https://github.com/golang/go/wiki/WebAssembly#executing-webassembly-with-node-js)
+Notes on compiling Go programs to WebAssembly and running them outside a browser — especially with Node.js.
+
+## Source
+
+- [Go Wiki: WebAssembly](https://go.dev/wiki/WebAssembly) (canonical; the old GitHub wiki redirects here)
+- [Executing WebAssembly with Node.js](https://github.com/golang/go/wiki/WebAssembly#executing-webassembly-with-node-js) (original bookmark)
+
+## Introduction
+
+Go 1.11 added an experimental port to WebAssembly. Go 1.21 added a **WASI** port (`GOOS=wasip1`) for syscall-backed Wasm outside the browser.
+
+WebAssembly (Wasm) is a portable binary instruction format for a stack-based VM — commonly used to run compiled code in browsers and on servers.
+
+## Compile a Go program to Wasm
+
+Set `GOOS=js` and `GOARCH=wasm`:
+
+```bash
+GOOS=js GOARCH=wasm go build -o main.wasm
+```
+
+Only **main packages** produce runnable Wasm modules. Library packages build to object files that cannot be executed directly.
+
+For Go 1.23 and earlier, support files lived under `misc/wasm`; from Go 1.24 onward use `$(go env GOROOT)/lib/wasm/`.
+
+## Run in a browser (quick test)
+
+Copy the JS shim and load the module from HTML:
+
+```bash
+cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" .
+```
+
+```html
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="wasm_exec.js"></script>
+    <script>
+      const go = new Go();
+      WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then(
+        (result) => {
+          go.run(result.instance);
+        },
+      );
+    </script>
+  </head>
+  <body></body>
+</html>
+```
+
+Serve `index.html`, `wasm_exec.js`, and `main.wasm` from any static file server. **Use matching Go versions** for the compiler and `wasm_exec.js`.
+
+## Executing WebAssembly with Node.js
+
+Node can run compiled Wasm modules — useful for testing and automation without a browser.
+
+### Add `go_js_wasm_exec` to PATH
+
+```bash
+export PATH="$PATH:$(go env GOROOT)/lib/wasm"
+GOOS=js GOARCH=wasm go run .
+# Hello, WebAssembly!
+GOOS=js GOARCH=wasm go test
+# PASS
+```
+
+`go_js_wasm_exec` is a wrapper that runs Go Wasm binaries under Node. Adding `lib/wasm` to `PATH` lets `go run` and `go test` find it automatically.
+
+### Use `-exec` without changing PATH
+
+```bash
+GOOS=js GOARCH=wasm go run -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec" .
+GOOS=js GOARCH=wasm go test -exec="$(go env GOROOT)/lib/wasm/go_js_wasm_exec"
+```
+
+### Run a built binary directly
+
+```bash
+GOOS=js GOARCH=wasm go build -o mybin .
+$(go env GOROOT)/lib/wasm/go_js_wasm_exec ./mybin
+```
+
+## WASI port (Go 1.21+)
+
+For server-side Wasm without the browser JS bridge:
+
+```bash
+GOOS=wasip1 GOARCH=wasm go build -o main.wasm
+```
+
+See [TinyGo with WebAssembly](https://tinygo.org/docs/guides/webassembly/) for much smaller binaries, and [Shrinking .wasm Code Size](./shrinking-.wasm-code-size.md) for Rust-oriented size tips that also apply conceptually to Go Wasm output.
+
+## Related
+
+- [Shrinking .wasm Code Size](./shrinking-.wasm-code-size.md)
+- [WebAssembly section](./README.md)

--- a/software-engineering/webrtc/testing-webrtc.md
+++ b/software-engineering/webrtc/testing-webrtc.md
@@ -1,3 +1,41 @@
+---
+title: Testing WebRTC
+description: Trickle ICE sample for validating STUN/TURN and candidate gathering.
+---
+
 # Testing WebRTC
 
-<https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice>
+Interactive sample for testing **trickle ICE** — how WebRTC gathers network candidates through STUN/TURN servers.
+
+## Source
+
+- [WebRTC samples — Trickle ICE](https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/)
+
+## What it does
+
+The page creates a `RTCPeerConnection` with configurable ICE servers, starts candidate gathering for a single audio stream, and prints each candidate as it arrives. A completion indicator shows when gathering finishes.
+
+### Permissions note
+
+If `getUserMedia` permission is not persisted for the origin, Chrome may only gather candidates from a **single interface**. Grant microphone/camera permission (or use the page’s permission button) to gather from multiple interfaces. See the [RTCWEB IP address handling](https://datatracker.ietf.org/doc/html/draft-ietf-rtcweb-ip-handling) recommendations.
+
+## How to interpret results
+
+| Candidate `type` | Meaning |
+|------------------|---------|
+| `srflx` | STUN reflexive candidate — STUN server works |
+| `relay` | TURN relay candidate — TURN server works |
+
+Add STUN/TURN URIs with optional username/password. Use the **IceTransports** constraint (`all` vs `relay`) to control which candidates are surfaced.
+
+When testing a single TURN/UDP server, the page can detect **wrong TURN credentials** during authentication.
+
+## Typical workflow
+
+1. Add your STUN and/or TURN server URIs.
+2. Optionally set TURN username and password.
+3. Click **Gather candidates**.
+4. Review the table: time, type, foundation, protocol, address, port, priority, URL, relay protocol.
+5. `onicecandidateerror` messages are not always fatal (e.g. IPv6 DNS lookup failure while IPv4 relay candidates still work).
+
+[Open the live sample →](https://webrtc.github.io/samples/src/content/peerconnection/trickle-ice/)


### PR DESCRIPTION
## Summary
- Replace link-only stub pages with imported content while keeping the original source URLs
- **Go and WASM** — full notes from go.dev wiki (compile, browser, Node.js `go_js_wasm_exec`, WASI pointer)
- Also enriched: Testing WebRTC, TCPDump, Shopify third-party marketplace orders, LXC device removal, BarcodeDetector CodePen demo

## Why
Empty pages (title + single URL) look bad on a public knowledge base linked from a CV. Source links stay; pages now have readable content.

## Test plan
- [x] `npm run docs:build` succeeds
- [ ] ~80 similar stubs remain across other sections (OBD2, microcontrollers, pen testing, etc.) for follow-up PRs