### PR TITLE
Import stub page content (batch 1)

### DIFF
--- a/microcontrollers-and-socs/esp32/esp32-wifi-penetration-tool.md
+++ b/microcontrollers-and-socs/esp32/esp32-wifi-penetration-tool.md
@@ -1,3 +1,39 @@
-# esp32-wifi-penetration-tool
+---
+title: ESP32 WiFi Penetration Tool
+description: ESP32-based WiFi security testing and attack toolkit.
+---
 
-<https://github.com/risinek/esp32-wifi-penetration-tool>
+# ESP32 WiFi Penetration Tool
+
+Firmware and tooling that turns an ESP32 into a portable WiFi penetration / security assessment device.
+
+## Source
+
+- [risinek/esp32-wifi-penetration-tool](https://github.com/risinek/esp32-wifi-penetration-tool)
+
+## Overview
+
+The project bundles WiFi attack and reconnaissance features for the ESP32 platform — useful for learning 802.11 security, lab testing, and authorized assessments only.
+
+## Typical capabilities
+
+- Monitor and sniff WiFi traffic (where hardware/firmware allows)
+- Deauthentication and related 802.11 frame injection patterns
+- Handshake capture for offline cracking workflows
+- Web or serial UI for controlling attacks from a phone or laptop
+
+## Hardware
+
+- ESP32 dev board (common: ESP32-WROOM modules)
+- Stable power supply; external antenna recommended for range
+
+## Build & flash
+
+Follow the repository README: clone, configure with `idf.py` or the documented build path, flash with [esptool](./esptool.md).
+
+> **Legal:** Use only on networks you own or have written permission to test. Unauthorized access is illegal in most jurisdictions.
+
+## Related
+
+- [Evil ESP](./evil-esp.md)
+- [ESP32 section](./README.md)

--- a/microcontrollers-and-socs/esp32/esptool.md
+++ b/microcontrollers-and-socs/esp32/esptool.md
@@ -1,5 +1,49 @@
+---
+title: esptool
+description: Official utility to flash firmware on Espressif ESP8266/ESP32 chips.
+---
+
 # esptool
 
-[https://github.com/espressif/esptool](https://github.com/espressif/esptool)§
+**esptool.py** is the canonical open-source utility for communicating with Espressif SoCs over the serial bootloader.
 
-<https://github.com/espressif/esptool>
+## Source
+
+- [espressif/esptool](https://github.com/espressif/esptool)
+- [Documentation](https://docs.espressif.com/projects/esptool/en/latest/)
+
+## Install
+
+```bash
+pip install esptool
+```
+
+## Common commands
+
+```bash
+# Chip identification
+esptool.py chip_id
+
+# Flash firmware
+esptool.py --port /dev/ttyUSB0 write_flash 0x1000 bootloader.bin 0x8000 partition-table.bin 0x10000 app.bin
+
+# Erase flash
+esptool.py --port /dev/ttyUSB0 erase_flash
+```
+
+## When you need it
+
+- Flashing [ESP32 WiFi Penetration Tool](./esp32-wifi-penetration-tool.md) or Arduino/IDF builds
+- Recovering bricked boards (hold BOOT, reset, flash)
+- Reading MAC, flash size, and security options
+
+## Tips
+
+- Use a reliable USB-serial adapter (CP2102, CH340, native USB on some boards)
+- Match baud rate and flash mode to your module datasheet
+- `--baud 460800` speeds up large writes when the link is stable
+
+## Related
+
+- [ESP32](./README.md)
+- [MicroControllers & SoCs](../README.md)

--- a/microcontrollers-and-socs/esp32/evil-esp.md
+++ b/microcontrollers-and-socs/esp32/evil-esp.md
@@ -1,7 +1,46 @@
 ---
-description: "\"https://github.com/tomellericcardo/EVIL-ESP\""
+title: EVIL-ESP
+description: Portable ESP8266 evil device — beacon spam, captive portal, evil twin.
 ---
 
 # EVIL-ESP
 
-<https://github.com/tomellericcardo/EVIL-ESP>
+A super portable evil device based on the **ESP8266**, running **MicroPython**, with a single button and small OLED display.
+
+## Source
+
+- [tomellericcardo/EVIL-ESP](https://github.com/tomellericcardo/EVIL-ESP)
+
+## Attacks
+
+| Attack | Behavior |
+|--------|----------|
+| **Beacon spammer** | Floods fake WiFi beacons so many phantom APs appear nearby |
+| **Captive portal** | Hosts a “free hotspot” and redirects users to a registration page (credentials logged, no real sign-in) |
+| **Evil twin** | Clones a protected network’s ESSID as an open AP; captive portal asks for the WiFi password “to complete a firmware upgrade” |
+
+Credentials land in `data/captive_portal/log.csv` and `data/evil_twin/log.csv` (viewable on-device or on the MicroPython console at startup).
+
+## Installation
+
+1. Wire an I2C OLED and push button (pin with pull-up)
+2. Flash MicroPython from the repo `firmware/` folder
+3. Edit `data/config/config.json` for hardware and preferences
+4. Upload the project tree (`ampy` or similar)
+
+Optional external antenna and power bank for portability. **Headless mode:** disable display/button in config and set the startup attack (evil twin needs target SSID in config).
+
+## Configuration mode
+
+Start config mode, join the board’s setup AP, and change attack options in the captive config page without reflashing.
+
+## Deauthentication note
+
+MicroPython cannot send 802.11 deauth frames on current Espressif SDK versions. For evil-twin workflows, the repo includes a separate [Arduino deauther sketch](https://github.com/tomellericcardo/EVIL-ESP/tree/master/deauther) for another ESP8266, or use authorized lab tooling on Linux.
+
+> Use responsibly and only on networks you own or are permitted to test.
+
+## Related
+
+- [ESP32 WiFi Penetration Tool](./esp32-wifi-penetration-tool.md)
+- [esptool](./esptool.md)

--- a/obd2/related-projects/canreader.md
+++ b/obd2/related-projects/canreader.md
@@ -1,7 +1,32 @@
 ---
-description: "\"https://github.com/autowp/CANreader\""
+title: CANreader
+description: Android CAN bus client — CanHacker-compatible, multiple adapters.
 ---
 
 # CANreader
 
-[https://github.com/autowp/CANreader](https://github.com/autowp/CANreader)
+Android application for communicating with CAN bus hardware. A CanHacker-style client for send/receive, logging, and adapter support.
+
+## Source
+
+- [autowp/CANreader](https://github.com/autowp/CANreader)
+- [English documentation](https://github.com/autowp/CANreader/blob/master/docs/en/README.md)
+
+## Features
+
+- Send and receive CAN frames (standard 11-bit and extended 29-bit, RTR)
+- High-speed and fault-tolerant CAN networks ([CANreader-FT](https://github.com/autowp/CANreader/blob/master/docs/en/canreader-device.md) only)
+- CanHacker (Windows) compatibility: TxList, Trace/RxList planned
+- Adapters: CANreader device, CanHacker, Seeed CAN Bus Shield
+- Connection types: USB serial (multiple chipsets via [UsbSerial](https://github.com/felHR85/UsbSerial)); Ethernet and Bluetooth planned
+
+## Requirements
+
+- Android device
+- [CANreader hardware](https://github.com/autowp/CANreader/blob/master/docs/en/canreader-device.md) or a [supported adapter](https://github.com/autowp/CANreader/blob/master/docs/en/adapters.md)
+
+> Useless without a CAN adapter attached.
+
+## Related
+
+- [OBD2 Related Projects](./README.md)

--- a/obd2/related-projects/carloop.io.md
+++ b/obd2/related-projects/carloop.io.md
@@ -1,3 +1,22 @@
+---
+title: Carloop.io
+description: OBD-II telematics hardware and companion apps (legacy).
+---
+
 # Carloop.io
 
-[https://www.carloop.io/apps/](https://www.carloop.io/apps/)
+Carloop was an OBD-II dongle and app ecosystem for reading vehicle data over CAN. The project paired low-cost hardware with mobile apps for logging and DIY telematics.
+
+## Source
+
+- [carloop.io/apps](https://www.carloop.io/apps/) — companion apps listing (site currently serves a placeholder page)
+
+## What it offered
+
+- OBD-II adapter hardware for CAN access from a phone or embedded board
+- Apps for reading PIDs, logging trips, and experimenting with vehicle data
+- Community guides for building wireless OBD scanners and dashboards
+
+## Note
+
+The public site may no longer host active app downloads. Treat this page as a bookmark for the ecosystem name; see [Creating A Wireless OBDII Scanner](../guides/creating-a-wireless-obdii-scanner.md) and [Related Projects](./README.md) for adjacent guides.

--- a/obd2/related-projects/open-garages.md
+++ b/obd2/related-projects/open-garages.md
@@ -1,3 +1,31 @@
+---
+title: Open Garages
+description: Public access, docs, and tools for understanding modern vehicle systems.
+---
+
 # Open Garages
 
-[https://github.com/OpenGarages](https://github.com/OpenGarages)
+Open Garages is a community organization providing public access, documentation, and tools to understand and research modern vehicle electronics.
+
+## Source
+
+- [Open Garages on GitHub](https://github.com/OpenGarages)
+- [opengarages.org](http://opengarages.org/)
+
+## Mission
+
+> Open Garages provide public access, documentation and tools necessary to understand today's modern vehicle systems.
+
+## Notable repositories
+
+| Repo | Description |
+|------|-------------|
+| [opengarages.github.io](https://github.com/OpenGarages/opengarages.github.io) | Project site |
+| [M2RET](https://github.com/OpenGarages/M2RET) | GVRET fork for Macchina M2 board |
+| [starter_light](https://github.com/OpenGarages/starter_light) | Arduino tower light for self-driving car racing |
+| [nrf-research-firmware](https://github.com/OpenGarages/nrf-research-firmware) | nRF24LU1+ USB dongle research firmware |
+
+## Related
+
+- [Car Hacking](../car-hacking/README.md)
+- [Related Projects](./README.md)

--- a/pen-testing/beef.md
+++ b/pen-testing/beef.md
@@ -1,7 +1,40 @@
 ---
-description: "\"https://github.com/beefproject/beef/wiki/Installation\""
+title: BeEF
+description: Browser Exploitation Framework — client-side penetration testing.
 ---
 
 # BeEF
 
-<https://github.com/beefproject/beef/wiki/Installation>
+**BeEF** (Browser Exploitation Framework) is a penetration testing tool focused on the web browser as the attack surface.
+
+## Source
+
+- [BeEF Installation wiki](https://github.com/beefproject/beef/wiki/Installation)
+- [beefproject/beef](https://github.com/beefproject/beef)
+
+## What it does
+
+Unlike server-side frameworks, BeEF hooks one or more browsers and uses them as beachheads for directed command modules and further attacks from within the browser context.
+
+## Requirements
+
+- macOS 10.5+ or modern Linux (Windows not supported)
+- Ruby 3.0+
+- SQLite 3.x
+- Node.js 10+
+- Gems from [Gemfile](https://github.com/beefproject/beef/blob/master/Gemfile)
+- macOS: `brew install selenium-server-standalone`
+
+## Quick start
+
+```bash
+./install
+./beef
+```
+
+Read the [Configuration wiki](https://github.com/beefproject/beef/wiki/Configuration) before exposing BeEF on a network.
+
+## Documentation
+
+- [User Guide](https://github.com/beefproject/beef/wiki)
+- [FAQ](https://github.com/beefproject/beef/wiki/FAQ)

--- a/pen-testing/decompilers/dex2jar.md
+++ b/pen-testing/decompilers/dex2jar.md
@@ -1,3 +1,36 @@
+---
+title: dex2jar
+description: Convert Android .dex files to Java .class / JAR for analysis.
+---
+
 # dex2jar
 
-<https://github.com/pxb1988/dex2jar>
+Tools to work with Android `.dex` and Java `.class` files — essential for reverse-engineering Android APKs.
+
+## Source
+
+- [pxb1988/dex2jar](https://github.com/pxb1988/dex2jar)
+- [Wiki](https://github.com/pxb1988/dex2jar/wiki) · [Releases](https://github.com/pxb1988/dex2jar/releases)
+
+## Components
+
+1. **dex-reader/writer** — read/write Dalvik Executable (`.dex`) files
+2. **d2j-dex2jar** — convert `.dex` to `.class` files (zipped as JAR)
+3. **smali/baksmali** — disassemble/assemble dex to smali
+4. **d2j-decrypt-string** — decrypt obfuscated strings in dex
+
+## Usage
+
+```bash
+./gradlew distZip
+cd dex-tools/build/distributions
+# unzip dex-tools-*-SNAPSHOT.zip
+sh d2j-dex2jar.sh -f ~/path/to/app.apk
+# → app-dex2jar.jar
+```
+
+Open the JAR in [jd-gui](./jd-gui.md) or a disassembler.
+
+## License
+
+Apache 2.0

--- a/pen-testing/decompilers/jd-gui.md
+++ b/pen-testing/decompilers/jd-gui.md
@@ -1,7 +1,37 @@
 ---
-description: Java Decompiler
+title: jd-gui
+description: Standalone Java decompiler GUI for .class files.
 ---
 
 # jd-gui
 
-<http://java-decompiler.github.io/>
+**JD-GUI** displays Java source reconstructed from `.class` files. Part of the Java Decompiler project alongside JD-Eclipse and JD-Core.
+
+## Source
+
+- [java-decompiler.github.io](http://java-decompiler.github.io/)
+- [JD-GUI releases](http://java-decompiler.github.io/)
+
+## Main features
+
+- Drag-and-drop `.class` files or JARs
+- Browse methods and fields in reconstructed source
+- Map stack trace line numbers back to decompiled code
+- Supports Java 5+ features (generics, annotations, enums)
+- Works with output from [dex2jar](./dex2jar.md)
+
+## Related tools
+
+| Tool | Role |
+|------|------|
+| **JD-GUI** | Standalone graphical viewer |
+| **JD-Eclipse** | Eclipse plugin for debugging without sources |
+| **JD-Core** | Library that reconstructs source from bytecode |
+
+All released under GPLv3.
+
+## Typical workflow
+
+1. `d2j-dex2jar.sh app.apk` → `app-dex2jar.jar`
+2. Open JAR in JD-GUI
+3. Inspect classes, export source if needed

--- a/pen-testing/drones/dji-firmware-tools-github-repo.md
+++ b/pen-testing/drones/dji-firmware-tools-github-repo.md
@@ -1,7 +1,43 @@
 ---
-description: "\"https://github.com/o-gs/dji-firmware-tools\""
+title: dji-firmware-tools Github Repo
+description: Extract, modify, and repack DJI multirotor firmware packages.
 ---
 
 # dji-firmware-tools Github Repo
 
-[View on GitHub](https://github.com/o-gs/dji-firmware-tools)
+Python tools for extracting, modding, and re-packaging firmware for [DJI](http://www.dji.com) multirotor drones.
+
+## Source
+
+- [o-gs/dji-firmware-tools](https://github.com/o-gs/dji-firmware-tools)
+- [Project wiki](https://github.com/o-gs/dji-firmware-tools/wiki)
+
+## Use cases
+
+- **Calibration** after component repair (gimbal Hall sensors, factory routines via custom packets)
+- **Parts identification** at board and component level (wiki has hardware maps)
+- **Flight parameter modification** via FC parameter arrays (hundreds of tunables)
+- **Firmware modification** — unpack, edit binaries, re-pack (signing may block flash on some models)
+- **Research** — capture UART/I2C traffic, parse flight logs, compare FW versions
+
+## Key tools (selection)
+
+| Script | Purpose |
+|--------|---------|
+| `dji_xv4_fwcon.py` | Extract/merge `xV4` firmware containers |
+| `dji_imah_fwsig.py` | Decrypt/un-sign `IM*H` modules |
+| `dji_mvfc_fwpak.py` | Second-layer FC decryption (Mavic-era) |
+| `amba_fwpak.py` / `amba_romfs.py` | Ambarella partition / ROMFS extraction |
+| `arm_bin2elf.py` | Wrap ARM binaries as ELF for disassembly |
+| `comm_serialtalk.py` | Send DUML packets, read responses |
+| `comm_og_service_tool.py` | Service functions (params, gimbal calib) |
+| `comm_dat2pcap.py` | Convert `FLY*.DAT` logs to PCAP |
+
+Run any tool without arguments or with `--help` for usage. See `tests/` for worked examples.
+
+> **No step-by-step instructions** are provided intentionally — tools target engineers who understand the risks. Use at your own risk; investigate warnings before flashing modified firmware.
+
+## Related
+
+- [Drones pen-testing section](./README.md)
+- [dji-firmware-tools](../../drones/dji-firmware-tools.md)

--- a/random/torrents-and-dht-network/magnetico.md
+++ b/random/torrents-and-dht-network/magnetico.md
@@ -1,7 +1,49 @@
 ---
-description: Autonomous (self-hosted) BitTorrent DHT search engine suite.
+title: magnetico
+description: Autonomous BitTorrent DHT crawler — build a searchable magnet index.
 ---
 
-# Magnetico
+# magnetico
 
-<https://github.com/DevinNorgarb/magnetico>
+**magnetico** crawls the BitTorrent **DHT** (Distributed Hash Table) without trackers or torrent files, building a local database of info hashes and metadata.
+
+## Source
+
+- [DevinNorgarb/magnetico](https://github.com/DevinNorgarb/magnetico) (fork)
+- Upstream: [boramalper/magnetico](https://github.com/boramalper/magnetico) · [magnetico.org](https://magnetico.org/)
+
+## How it works
+
+1. Join the mainline DHT as a node
+2. Discover info hashes from `announce_peer` / `get_peers` traffic
+3. Fetch metadata via **BEP 9** (ut_metadata) when peers are available
+4. Store names, file lists, and sizes in SQLite for search
+
+## Components
+
+| Binary | Role |
+|--------|------|
+| `magneticod` | Crawler daemon |
+| `magneticow` | Web UI for searching the index |
+
+## Quick start
+
+```bash
+# Build (Go)
+go install github.com/boramalper/magnetico@latest
+
+magneticod   # runs crawler
+magneticow   # web interface (default :8080)
+```
+
+See the README for Docker, systemd, and resource tuning (crawling is network- and disk-intensive).
+
+## Use cases
+
+- Research on DHT topology and metadata availability
+- Private search index (not a replacement for public indexers)
+- Understanding how magnets propagate without central trackers
+
+## Related
+
+- [Torrents and DHT Network](./README.md)

--- a/scripts/stub-import-batches.json
+++ b/scripts/stub-import-batches.json
@@ -1,0 +1,114 @@
+{
+  "version": 1,
+  "next_batch": 2,
+  "batches": [
+    {
+      "id": 1,
+      "label": "OBD2 related + pen-testing repos + ESP32 tools + scrapers",
+      "files": [
+        "obd2/related-projects/canreader.md",
+        "obd2/related-projects/carloop.io.md",
+        "obd2/related-projects/open-garages.md",
+        "pen-testing/beef.md",
+        "pen-testing/decompilers/dex2jar.md",
+        "pen-testing/decompilers/jd-gui.md",
+        "pen-testing/drones/dji-firmware-tools-github-repo.md",
+        "microcontrollers-and-socs/esp32/esp32-wifi-penetration-tool.md",
+        "microcontrollers-and-socs/esp32/evil-esp.md",
+        "microcontrollers-and-socs/esp32/esptool.md",
+        "random/torrents-and-dht-network/magnetico.md",
+        "web-scraping/scrapers.md"
+      ]
+    },
+    {
+      "id": 2,
+      "label": "Raspberry Pi hotspot + Pi tools + install scripts (part 1)",
+      "files": [
+        "microcontrollers-and-socs/raspberry-pi/awesome-raspberry-pi.md",
+        "microcontrollers-and-socs/raspberry-pi/use-raspberry-pi-as-jtag-debugger.md",
+        "microcontrollers-and-socs/raspberry-pi/install-proxmox-on-a-raspberry-pi/pimox-pimox7.md",
+        "microcontrollers-and-socs/raspberry-pi/raspberry-pi-hotspot/hotspotos.md",
+        "microcontrollers-and-socs/raspberry-pi/raspberry-pi-hotspot/kupiki-hotspot-script.md",
+        "microcontrollers-and-socs/raspberry-pi/raspberry-pi-hotspot/rpi-wireless-hotspot.md",
+        "microcontrollers-and-socs/raspberry-pi/sim800l-gps-gprs-at-commands.md",
+        "snippets-and-scripts/install-scripts/python-libraries/poetry/README.md",
+        "snippets-and-scripts/install-scripts/samba-on-mac.md",
+        "snippets-and-scripts/install-scripts/rust.md",
+        "snippets-and-scripts/install-scripts/yarn.md",
+        "snippets-and-scripts/scripts/nginx-proxy-block.md"
+      ]
+    },
+    {
+      "id": 3,
+      "label": "Install scripts (part 2) + misc tutorials",
+      "files": [
+        "snippets-and-scripts/install-scripts/composer.md",
+        "snippets-and-scripts/install-scripts/install-oh-my-zsh.md",
+        "snippets-and-scripts/install-scripts/python-libraries/README.md",
+        "snippets-and-scripts/install-scripts/python-libraries/pyenv/README.md",
+        "snippets-and-scripts/install-scripts/sdkman.md",
+        "misc/tutorials/install-ghost-blogging-platform-on-ubuntu.md",
+        "misc/tutorials/setting-up-k3s-in-lxc-containers-using-netmaker/install-k3s/README.md",
+        "random/adhd-and-programming/README.md",
+        "self-hosting/hardware/dell-poweredge-2950.md",
+        "pen-testing/drones/video-guide.md",
+        "pen-testing/kali-linux/README.md",
+        "robotics/sitl-1.md"
+      ]
+    },
+    {
+      "id": 4,
+      "label": "Software engineering — docs, automation, android, ML",
+      "files": [
+        "software-engineering/documentation/tools.md",
+        "software-engineering/documentation/general.md",
+        "software-engineering/documentation/README.md",
+        "software-engineering/automation/README.md",
+        "software-engineering/android-app-development/capacitor.md",
+        "software-engineering/machine-learning/google-mlkit/README.md",
+        "software-engineering/machine-learning/google-mlkit/mlkit-barcode-android.md",
+        "software-engineering/machine-learning/openmv.io.md",
+        "software-engineering/programming/frontend/README.md",
+        "software-engineering/programming/frontend/javascript/README.md",
+        "software-engineering/cryptocurrencies/trading-bots.md",
+        "software-engineering/kubernetes/k3s.md"
+      ]
+    },
+    {
+      "id": 5,
+      "label": "Software engineering — networking, browsers, containers, shopify",
+      "files": [
+        "software-engineering/networking/vpn/netmaker/README.md",
+        "software-engineering/networking/web-sockets/README.md",
+        "software-engineering/networking/web-sockets/socket-client-tool.md",
+        "software-engineering/browsers/README.md",
+        "software-engineering/browsers/extensions/README.md",
+        "software-engineering/browsers/apis/README.md",
+        "software-engineering/containerisation/docker.md",
+        "software-engineering/kubernetes/rancher.md",
+        "software-engineering/shopify-dev/carrier-services.md",
+        "software-engineering/shopify-dev/fulfilment-orders.md",
+        "software-engineering/webrtc/README.md",
+        "software-engineering/tooling-extras/testing/README.md"
+      ]
+    },
+    {
+      "id": 6,
+      "label": "GIS + IP cameras + OBD2 remaining",
+      "files": [
+        "gis/geocoding/README.md",
+        "gis/geocoding/mapbox-geocoding-api/README.md",
+        "gis/tile38.md",
+        "gis/vector-tiles.md",
+        "gis/mapbox-storytelling.md",
+        "ip-cameras/protocols/onvif.md",
+        "obd2/guides/creating-a-wireless-obdii-scanner.md",
+        "obd2/the-car-hacker-handbook-pdf.md",
+        "obd2/vehicle-tracking/README.md",
+        "obd2/obdii-simulators/libraries/README.md",
+        "drones/dji-docs-android/introduction.md",
+        "microcontrollers-and-socs/arduino/k3s-tutorial-arduino.md"
+      ]
+    }
+  ]
+}

--- a/web-scraping/scrapers.md
+++ b/web-scraping/scrapers.md
@@ -1,7 +1,50 @@
 ---
-description: Curated list of web scrapers and crawling tools
+title: Scrapers
+description: Curated list of web scraping libraries and frameworks.
 ---
 
 # Scrapers
 
-A curated list of web scrapers and crawling tools. See [cassidoo/scrapers](https://github.com/cassidoo/scrapers) for the original collection.
+Reference list of tools for extracting structured data from websites — from single-page fetch to large-scale crawl pipelines.
+
+## Source
+
+- [cassidoo/scrapers](https://github.com/cassidoo/scrapers) — original curated collection
+
+## Python
+
+| Library | Notes |
+|---------|--------|
+| [Beautiful Soup](https://www.crummy.com/software/BeautifulSoup/) | HTML/XML parsing; pairs with `requests` |
+| [Scrapy](https://scrapy.org/) | Full crawl framework, pipelines, middlewares |
+| [Playwright](https://playwright.dev/python/) | Headless browser automation |
+| [Selenium](https://www.selenium.dev/) | Browser automation (heavier, widely used) |
+| [httpx](https://www.python-httpx.org/) | Async HTTP client |
+| [lxml](https://lxml.de/) | Fast XML/HTML parsing |
+
+## Node.js
+
+| Library | Notes |
+|---------|--------|
+| [Cheerio](https://cheerio.js.org/) | jQuery-like server-side HTML |
+| [Puppeteer](https://pptr.dev/) | Chrome DevTools Protocol automation |
+| [Playwright](https://playwright.dev/) | Cross-browser automation |
+
+## Other
+
+| Tool | Notes |
+|------|--------|
+| [Colly](https://go-colly.org/) | Go crawling framework |
+| [Mechanize](https://github.com/sparklemotion/mechanize) | Ruby stateful browsing |
+| [wget / curl](https://curl.se/) | Simple fetch and mirror |
+
+## Practices
+
+- Respect `robots.txt` and site Terms of Service
+- Rate-limit and identify your bot with a contact User-Agent
+- Prefer APIs and official feeds when available
+- Cache responses; use incremental crawls for large sites
+
+## Related
+
+- [Web Scraping](./README.md)


### PR DESCRIPTION
## Summary

- Enriches 12 stub pages (OBD2 related projects, pen-testing tools, ESP32 WiFi tools, magnetico, scrapers) with structured content and preserved source links.
- Adds `scripts/stub-import-batches.json` to track remaining stub-import batches (next: batch 2).

## Test plan

- [ ] `npm run docs:build` passes
- [ ] Spot-check a few pages on preview (source links, headings, no broken internal links)