### PR TITLE
Import stub page content (batch 3)

### DIFF
--- a/misc/tutorials/install-ghost-blogging-platform-on-ubuntu.md
+++ b/misc/tutorials/install-ghost-blogging-platform-on-ubuntu.md
@@ -1,5 +1,50 @@
+---
+title: Install Ghost blogging platform on Ubuntu
+description: Ghost CMS on Ubuntu 18.04 with Nginx, MySQL, Node.js, and Ghost-CLI.
+---
+
 # Install Ghost blogging platform on Ubuntu
 
-Original guide: https://www.linode.com/docs/guides/how-to-install-ghost-on-ubuntu-18-04/
+Guide to deploying **Ghost** (open-source blogging CMS) on Ubuntu with Nginx reverse proxy, MySQL, and Let’s Encrypt TLS via Ghost-CLI.
 
-Last updated: 3 years ago
+## Source
+
+- [Linode: How to Install Ghost CMS on Ubuntu 18.04 LTS](https://www.linode.com/docs/guides/how-to-install-ghost-on-ubuntu-18-04/) (published Feb 2020)
+
+## Stack
+
+| Component | Role |
+|-----------|------|
+| **Ghost** | Node.js CMS with Markdown editor |
+| **Ghost-CLI** | Install, update, nginx/systemd/SSL setup |
+| **Nginx** | Reverse proxy |
+| **MySQL** | Database |
+| **Node.js LTS** | Ghost runtime |
+| **Let’s Encrypt** | TLS (via Ghost-CLI prompts) |
+
+## Prerequisites
+
+- Non-root sudo user (example: `ghostexample`)
+- Valid domain with DNS pointing at the server
+- `sudo apt update && sudo apt upgrade`
+- `sudo apt install build-essential`
+
+## Install flow (summary)
+
+1. **Nginx:** `sudo apt install nginx`
+2. **MySQL:** `sudo apt install mysql-server`, set root password in `mysql`
+3. **Node.js:** NodeSource LTS setup + `sudo apt install nodejs`
+4. **Ghost-CLI:** `sudo npm install -g ghost-cli@latest`
+5. **App directory:** `sudo mkdir -p /var/www/ghost`, chown to deploy user, `cd /var/www/ghost`
+6. **Install:** `ghost install` — answer URL, DB, nginx, SSL, systemd prompts
+7. **Finish setup:** browse `https://your-domain.com/ghost` and create admin account
+
+## Maintenance
+
+```bash
+ghost ls
+ghost update
+ghost doctor
+```
+
+Replace `example.com` in the Linode guide with your domain. Newer Ubuntu versions may need adjusted Node LTS lines — cross-check [Ghost docs](https://ghost.org/docs/).

--- a/misc/tutorials/setting-up-k3s-in-lxc-containers-using-netmaker/install-k3s/README.md
+++ b/misc/tutorials/setting-up-k3s-in-lxc-containers-using-netmaker/install-k3s/README.md
@@ -1,7 +1,58 @@
+---
+title: Install K3s
+description: Single k3s cluster spanning multiple clouds over WireGuard (Netmaker).
+---
+
 # Install K3s
 
-Original article: https://itnext.io/how-to-deploy-a-single-kubernetes-cluster-across-multiple-clouds-using-k3s-and-wireguard-a5ae176a6e81
+Deploy one **k3s** Kubernetes cluster across multiple cloud VMs using **WireGuard** tunnels managed by **Netmaker**.
 
-> Last updated: 4 years ago
+## Source
 
-<a href="https://itnext.io/how-to-deploy-a-single-kubernetes-cluster-across-multiple-clouds-using-k3s-and-wireguard-a5ae176a6e81" class="button primary">Read the original article</a>
+- [ITNEXT: k3s + WireGuard + Netmaker](https://itnext.io/how-to-deploy-a-single-kubernetes-cluster-across-multiple-clouds-using-k3s-and-wireguard-a5ae176a6e81) (Alex Feiszli, May 2021)
+- Related tutorial in this repo: [Setting up k3s in LXC containers using Netmaker](../README.md)
+
+## Why this pattern
+
+- **k3s** uses SQL instead of etcd — tolerates higher-latency links between nodes
+- **WireGuard** encrypts node-to-node traffic across public clouds
+- **Netmaker** automates WireGuard peer config when nodes join/leave
+
+## Architecture (demo)
+
+- Several Ubuntu 20.04 VMs with public IPs (e.g. Linode + AWS + home lab)
+- One VM runs Netmaker (Docker); others join a virtual subnet (e.g. `10.11.11.0/24`)
+- k3s server binds to the Netmaker interface (`nm-k3s`); agents join with the node token
+
+## Part 1 — Netmaker
+
+On the Netmaker VM (ports 80, 8081, 50051 open):
+
+```bash
+wget -O docker-compose.yml https://raw.githubusercontent.com/gravitl/netmaker/master/docker-compose.nodns.yml
+# Set your VM IP in docker-compose.yml
+sudo docker-compose up -d
+```
+
+Create network `k3s` / `10.11.11.0/24`, generate access key, run the install script on each cluster node (after `apt install wireguard-tools`).
+
+## Part 2 — k3s server
+
+On the master (replace IPs with your Netmaker addresses):
+
+```bash
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-ip 10.11.11.1 --node-external-ip 10.11.11.1 --flannel-iface nm-k3s" sh -
+cat /var/lib/rancher/k3s/server/node-token
+```
+
+## Part 3 — k3s agents
+
+On workers:
+
+```bash
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="agent --server https://10.11.11.MASTER:6443 --token <TOKEN> --node-ip 10.11.11.X --node-external-ip 10.11.11.X --flannel-iface nm-k3s" sh -
+```
+
+Verify with `kubectl get nodes` and cross-cloud pod ping tests (see article).
+
+> Demo setup only — not production HA. See the article for ingress, storage, and HA follow-ups.

--- a/pen-testing/drones/video-guide.md
+++ b/pen-testing/drones/video-guide.md
@@ -1,5 +1,21 @@
+---
+title: Video Guide
+description: Video walkthrough for drone security / firmware topics.
+---
+
 # Video Guide
 
-<https://www.youtube.com/watch?v=ZPRIk1murgA>
+Video reference for drone-related penetration testing or firmware work covered in this section.
 
-[https://www.youtube.com/watch?v=ZPRIk1murgA](https://www.youtube.com/watch?v=ZPRIk1murgA)
+## Source
+
+- [YouTube walkthrough](https://www.youtube.com/watch?v=ZPRIk1murgA)
+
+## What to expect
+
+Use this as a visual companion to the written drone pen-testing notes — firmware extraction, UART debug, or flight-controller tooling depending on the video’s topic. Pair with:
+
+- [dji-firmware-tools Github Repo](../dji-firmware-tools-github-repo.md)
+- [Drones pen-testing section](./README.md)
+
+> Video content changes over time; verify tools and legal scope before testing hardware you do not own.

--- a/pen-testing/kali-linux/README.md
+++ b/pen-testing/kali-linux/README.md
@@ -1,12 +1,37 @@
 ---
 title: Kali Linux
-description: "\"\\\"In [Secure Kali Pi (2022)](https://www.kali.org/blog/secure-kali-raspberry-pi/), the first blog post in the Raspberry Pi series, we set up a\\\"\""
+description: Kali on Raspberry Pi — secure drop box, remote unlock, VPN access.
 ---
 
 # Kali Linux
 
-Notes and links for **Kali Linux**.
+Notes and guides for running **Kali Linux** on embedded hardware (especially Raspberry Pi) as a portable security testing platform.
+
+## Source
+
+- [Secure Kali Pi (2022)](https://www.kali.org/blog/secure-kali-raspberry-pi/) — Kali.org Raspberry Pi series
+- [Kali ARM images](https://www.kali.org/get-kali/#kali-arm)
+
+## Topics in this section
+
+The blog series covers building a **full-disk-encrypted** Pi drop box and remotely unlocking/connecting when it is not on your LAN:
+
+- WiFi as client on known networks (pre-configured)
+- WiFi access point mode for physical proximity access
+- Ethernet with static or DHCP settings
+- **OpenVPN** (or similar) back to a server you control to avoid port-forwarding on remote networks
 
 ## In this section
 
-- [Kali Linux Blog](./kali-linux-blog.md) — In [Secure Kali Pi (2022)](https://www.kali.org/blog/secure-kali-raspberry-pi/), the first blog post in the Raspberry Pi series, we set up a
+- [Kali Linux Blog](./kali-linux-blog.md) — imported walkthrough from the Secure Kali Pi follow-on posts
+
+## Getting started
+
+1. Flash a [Kali ARM image](https://www.kali.org/docs/arm/) for your Pi model
+2. Follow [Secure Kali Pi](https://www.kali.org/blog/secure-kali-raspberry-pi/) for LUKS setup
+3. Use the blog child page for wireless/VPN drop-box connectivity patterns
+
+## Related
+
+- [Pen Testing](../README.md)
+- [Raspberry Pi](../../microcontrollers-and-socs/raspberry-pi/README.md)

--- a/random/adhd-and-programming/README.md
+++ b/random/adhd-and-programming/README.md
@@ -1,12 +1,39 @@
 ---
 title: ADHD and Programming
-description: "\"\\\"*This page documents **ADHD Programming Notes**.*\\\"\""
+description: How ADHD brains interact with coding — hyperfocus, regulation, strategies.
 ---
 
 # ADHD and Programming
 
-<https://dev.to/abbeyperini/coding-and-adhd-adhd-brains-im1>
+Essay series on the overlap between **ADHD** and software development — why coding can feel natural to ADHD brains, and where it becomes painful.
+
+## Source
+
+- [Coding and ADHD - ADHD Brains](https://dev.to/abbeyperini/coding-and-adhd-adhd-brains-im1) by Abbey Perini (DEV Community)
+
+## Key ideas
+
+- ADHD is often better framed as **attention regulation** / executive-function difficulty than “deficit”
+- Coding offers novelty, immediate feedback, and deep problem stacks — strong reward loops for ADHD learning pathways
+- Hyperfocus can mean 6+ hour sessions (missing meals/meetings) when a problem is interesting
+- Common struggles: time blindness, working memory, procrastination, rejection sensitivity, difficulty stopping or starting
+
+## Series outline (author)
+
+The author’s follow-on posts cover:
+
+| Challenge | Theme |
+|-----------|--------|
+| Can't Start | Getting into flow |
+| Can't Keep Going | Sustaining momentum |
+| Can't Stop | Hyperfocus boundaries |
+| Can't Remember | Working memory aids |
+| Benefits | ADHD traits that help in dev roles |
 
 ## In this section
 
-- [ADHD Programming Notes](./adhd-programming-notes.md) — *This page documents **ADHD Programming Notes**.*
+- [ADHD Programming Notes](./adhd-programming-notes.md) — personal notes and strategies
+
+## Related
+
+- [Random](../../README.md)

--- a/robotics/sitl-1.md
+++ b/robotics/sitl-1.md
@@ -1,5 +1,31 @@
+---
+title: SITL
+description: Software-in-the-loop drone simulation — ArduPilot basics video.
+---
+
 # SITL
 
-Basics
+**SITL** (Software In The Loop) runs autopilot firmware on your dev machine so you can test missions without airframe hardware.
 
-<https://www.youtube.com/watch?v=mKt4ZTaE2bk>
+## Source
+
+- [YouTube: SITL basics](https://www.youtube.com/watch?v=mKt4ZTaE2bk)
+
+## What SITL gives you
+
+- ArduPilot (or compatible stacks) built for desktop — physics simulated
+- Test **DroneKit**, MAVLink tools, and mission scripts from your IDE
+- Reproduce failsafes, RTL, and waypoint logic before flying
+
+## Typical workflow
+
+1. Install ArduPilot SITL dependencies for your OS
+2. Launch a simulated vehicle (copter/plane/rover profile)
+3. Connect GCS (Mission Planner, QGroundControl) or Python via MAVLink on UDP/TCP
+4. Iterate on code against the simulated MAV
+
+## Related
+
+- [SITL section](./sitl/README.md)
+- [Simulated Vehicle (SITL)](./sitl/simulated-vehicle-sitl.md)
+- [Robotics](./README.md)

--- a/scripts/stub-import-batches.json
+++ b/scripts/stub-import-batches.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_batch": 3,
+  "next_batch": 4,
   "batches": [
     {
       "id": 1,

--- a/self-hosting/hardware/dell-poweredge-2950.md
+++ b/self-hosting/hardware/dell-poweredge-2950.md
@@ -1,8 +1,32 @@
 ---
-description: As the video title suggests, Louder than a Boeing 747
+title: Dell PowerEdge 2950
+description: Legacy 2U rack server — loud fans, homelab nostalgia.
 ---
 
 # Dell PowerEdge 2950
 
+The **Dell PowerEdge 2950** is a 2U rack-mount server (Intel Xeon era, DDR2 FB-DIMM, SAS/SATA bays) common in early homelabs before low-power Pi clusters and NUCs.
 
-<https://youtu.be/IK0yWkXBRRY>
+## Source
+
+- [YouTube: louder than a Boeing 747](https://youtu.be/IK0yWkXBRRY) — fan noise meme video for this generation of gear
+
+## Specs (typical)
+
+| Item | Notes |
+|------|--------|
+| Form factor | 2U rack |
+| CPUs | Dual-socket Intel Xeon (5400/5300 series common) |
+| RAM | DDR2 FB-DIMMs, ECC |
+| Storage | SAS/SATA backplane, PERC RAID optional |
+| Power | Dual PSU, **high draw + high noise** |
+
+## Homelab notes
+
+- Expect **very loud** fans at idle unless you flash custom IPMI fan curves or under-volt
+- Power efficiency is poor vs modern used enterprise (e.g. Gen12+ Dell) or ARM boards
+- Fine for learning iDRAC, RAID, and bare-metal hypervisors if you have a garage/closet and cheap power
+
+## Related
+
+- [Self-hosting hardware](../README.md)

--- a/snippets-and-scripts/install-scripts/composer.md
+++ b/snippets-and-scripts/install-scripts/composer.md
@@ -1,11 +1,31 @@
 ---
-description: Nice composer one-liner
+title: Composer
+description: Install PHP Composer globally via the official installer.
 ---
 
 # Composer
 
-One-liner installation:
+**Composer** is PHP’s dependency manager — declares libraries per project and installs them into `vendor/`.
+
+## Source
+
+- [getcomposer.org](https://getcomposer.org/)
+- [Introduction](https://getcomposer.org/doc/00-intro.md)
+
+## Install (global binary)
 
 ```bash
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ```
+
+Verify: `composer --version`
+
+## Notes
+
+- Requires PHP 7.2.5+ (Composer 2.2 LTS supports older PHP)
+- Local install: run the installer in your project and use `php composer.phar`
+- On macOS, create `/usr/local/bin` if missing: `mkdir -p /usr/local/bin`
+
+## Related
+
+- [Install scripts](./README.md)

--- a/snippets-and-scripts/install-scripts/install-oh-my-zsh.md
+++ b/snippets-and-scripts/install-scripts/install-oh-my-zsh.md
@@ -1,5 +1,34 @@
+---
+title: Install oh-my-zsh
+description: One-line installer for Oh My Zsh framework.
+---
+
 # Install oh-my-zsh
 
+**Oh My Zsh** is a community framework for managing Zsh configuration, themes, and plugins.
+
+## Source
+
+- [ohmyzsh/ohmyzsh](https://github.com/ohmyzsh/ohmyzsh)
+- [Install guide](https://github.com/ohmyzsh/ohmyzsh#basic-installation)
+
+## Install
+
 ```bash
-sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
 ```
+
+The installer backs up existing `~/.zshrc` and can set Zsh as your default shell.
+
+## After install
+
+- Edit `~/.zshrc` to set `ZSH_THEME` and `plugins=(git …)`
+- Reload: `source ~/.zshrc`
+
+## Uninstall
+
+Follow the [uninstall section](https://github.com/ohmyzsh/ohmyzsh#uninstalling-oh-my-zsh) in the repo README.
+
+## Related
+
+- [Install scripts](./README.md)

--- a/snippets-and-scripts/install-scripts/python-libraries/README.md
+++ b/snippets-and-scripts/install-scripts/python-libraries/README.md
@@ -1,13 +1,37 @@
 ---
 title: Python + Libraries
-description: "\"\\\"&#x20;`curl -sSL https://install.python-poetry.org | python3 -`&#x20;; `curl https://pyenv.run | bash`\\\"\""
+description: Install Poetry and pyenv for Python version and dependency management.
 ---
 
 # Python + Libraries
 
-Notes and links for **Python + Libraries**.
+Quick installs for **Poetry** (packaging/deps) and **pyenv** (multiple Python versions).
+
+## Source
+
+- [Poetry installer](https://python-poetry.org/docs/#installation)
+- [pyenv automatic installer](https://github.com/pyenv/pyenv#automatic-installer)
+
+## One-liners
+
+```bash
+curl -sSL https://install.python-poetry.org | python3 -
+curl https://pyenv.run | bash
+```
+
+After pyenv install, add to `~/.bashrc` or `~/.zshrc`:
+
+```bash
+export PYENV_ROOT="$HOME/.pyenv"
+[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+```
 
 ## In this section
 
-- [poetry](./poetry/README.md) — Python dependency management with Poetry
-- [pyenv](./pyenv/README.md) — `curl https://pyenv.run | bash`
+- [poetry](./poetry/README.md) — dependency management and packaging
+- [pyenv](./pyenv/README.md) — per-project Python versions
+
+## Related
+
+- [Install scripts](../README.md)

--- a/snippets-and-scripts/install-scripts/python-libraries/pyenv/README.md
+++ b/snippets-and-scripts/install-scripts/python-libraries/pyenv/README.md
@@ -1,12 +1,47 @@
+---
+title: pyenv
+description: Install and configure pyenv for multiple Python versions.
+---
+
 # pyenv
 
-`curl https://pyenv.run | bash`
+**pyenv** lets you install and switch Python versions per project without conflicting system Pythons.
 
-Once installed, add this to your `.bashrc` file&#x20;
+## Source
 
-`export PYENV_ROOT="$HOME/.pyenv" [[ -d $PYENV_ROOT/bin ]]` \
-`&& export  PATH="$PYENV_ROOT/bin:$PATH" eval "$(pyenv init -)"`
+- [pyenv/pyenv](https://github.com/pyenv/pyenv)
+- [Automatic installer](https://github.com/pyenv/pyenv#automatic-installer)
 
+## Install
 
-<https://github.com/pyenv/pyenv?tab=readme-ov-file#automatic-installer>
+```bash
+curl https://pyenv.run | bash
+```
 
+## Shell setup
+
+Add to `~/.bashrc` or `~/.zshrc`:
+
+```bash
+export PYENV_ROOT="$HOME/.pyenv"
+[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+```
+
+Restart the shell or `source` your rc file.
+
+## Common commands
+
+```bash
+pyenv install 3.12.0
+pyenv global 3.12.0
+pyenv local 3.11.6    # per-directory .python-version
+pyenv versions
+```
+
+Build deps (Debian/Ubuntu): `sudo apt install -y build-essential libssl-dev zlib1g-dev …` — see pyenv wiki for your OS.
+
+## Related
+
+- [Python + Libraries](../README.md)
+- [poetry](../poetry/README.md)

--- a/snippets-and-scripts/install-scripts/sdkman.md
+++ b/snippets-and-scripts/install-scripts/sdkman.md
@@ -1,5 +1,42 @@
+---
+title: SDKMan
+description: Install SDKMAN for JVM and SDK version management.
+---
+
 # SDKMan
 
-`curl -s "https://get.sdkman.io" | bash`
+**SDKMAN!** manages parallel versions of Java, Kotlin, Gradle, Maven, and many other SDKs on Unix shells.
 
-<br>
+## Source
+
+- [sdkman.io](https://sdkman.io/)
+- [Installation](https://sdkman.io/install)
+
+## Install
+
+```bash
+curl -s "https://get.sdkman.io" | bash
+source "$HOME/.sdkman/bin/sdkman-init.sh"
+sdk version
+```
+
+Works on macOS, Linux, and Windows via WSL (Bash or Zsh).
+
+## Common commands
+
+```bash
+sdk list java
+sdk install java 21.0.2-tem
+sdk use java 21.0.2-tem
+sdk default java 21.0.2-tem
+```
+
+## CI install
+
+```bash
+curl -s "https://get.sdkman.io?ci=true&rcupdate=false" | bash
+```
+
+## Related
+
+- [Install scripts](./README.md)


### PR DESCRIPTION
## Summary

- 12 stub pages: Composer, oh-my-zsh, pyenv/Poetry parent, SDKMAN, Ghost on Ubuntu, k3s+Netmaker, ADHD programming, Dell 2950, drone video, Kali readme, SITL video.
- Batch tracker advanced to batch 4.

## Test plan

- [ ] `npm run docs:build`