### PR TITLE
Import stub page content (batch 4)

### DIFF
--- a/scripts/stub-import-batches.json
+++ b/scripts/stub-import-batches.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_batch": 4,
+  "next_batch": 5,
   "batches": [
     {
       "id": 1,

--- a/software-engineering/android-app-development/capacitor.md
+++ b/software-engineering/android-app-development/capacitor.md
@@ -1,5 +1,42 @@
+---
+title: Capacitor
+description: Ionic Capacitor — ship web apps as native iOS/Android with a JS bridge.
+---
+
 # Capacitor
 
-Cross-platform native runtime for web apps. See also [Cordova](./cordova.md).
+**Capacitor** is Ionic’s cross-platform native runtime: wrap your web app (React, Vue, Angular, etc.) in a native shell and call device APIs via plugins.
 
-- [Capacitor docs](https://capacitorjs.com/docs)
+## Source
+
+- [Capacitor documentation](https://capacitorjs.com/docs)
+- [Getting started](https://capacitorjs.com/docs/getting-started)
+- [ionic-team/capacitor](https://github.com/ionic-team/capacitor)
+
+## Requirements
+
+- `package.json` and a built web assets directory (`dist`, `www`, `build`, …)
+- `index.html` with a `<head>` tag (required for plugin injection)
+
+## Add to an existing web app
+
+```bash
+npm i @capacitor/core
+npm i -D @capacitor/cli
+npx cap init
+npm i @capacitor/android @capacitor/ios
+npx cap add android
+npx cap add ios
+npm run build
+npx cap sync
+```
+
+Open native projects with `npx cap open android` / `npx cap open ios`.
+
+## vs Cordova
+
+Capacitor is the modern Ionic stack — first-class TypeScript, maintained native tooling, and a simpler plugin model. See [Cordova](./cordova.md) for legacy hybrid apps.
+
+## Related
+
+- [Android App Development](./README.md)

--- a/software-engineering/automation/README.md
+++ b/software-engineering/automation/README.md
@@ -1,13 +1,34 @@
 ---
 title: Automation
-description: "\"\\\"This is the documentation for [n8n](https://n8n.io/), a [fair-code](http://faircode.io/) licensed node-based workflow automation tool.\\\"\""
+description: Workflow automation with n8n and browser testing with Cypress.
 ---
 
 # Automation
 
-Notes and links for **Automation**.
+Notes on **workflow automation** (n8n) and **browser end-to-end testing** (Cypress).
+
+## Source
+
+- [n8n documentation](https://docs.n8n.io/)
+- [n8n.io](https://n8n.io/) — fair-code workflow automation
+
+## n8n overview
+
+**n8n** (pronounced “n-eight-n”) connects apps with APIs using a visual node editor — low-code data transforms, webhooks, schedules, and AI-assisted flows.
+
+| Option | Notes |
+|--------|--------|
+| **Cloud** | Hosted by n8n |
+| **npm / Docker** | Self-host for privacy |
+| **Integrations** | Large connector library |
+
+Fair-code license — source available with usage tiers for commercial scale.
 
 ## In this section
 
-- [n8n Docs](./n8n-docs.md) — This is the documentation for [n8n](https://n8n.io/), a [fair-code](http://faircode.io/) licensed node-based workflow automation tool.
-- [Browser](./browser/README.md) — Cypress is a next generation front end testing tool built for the modern web. We address the key pain points developers and QA engineers fac
+- [n8n Docs](./n8n-docs.md) — imported n8n reference material
+- [Browser](./browser/README.md) — Cypress E2E testing
+
+## Related
+
+- [Software Engineering](../README.md)

--- a/software-engineering/cryptocurrencies/trading-bots.md
+++ b/software-engineering/cryptocurrencies/trading-bots.md
@@ -1,5 +1,43 @@
+---
+title: Trading Bots
+description: Open-source crypto trading automation with Freqtrade.
+---
+
 # Trading Bots
 
-Open-source crypto trading bot framework:
+**Freqtrade** is a Python crypto trading bot with backtesting, hyperopt, Telegram/WebUI control, and strategy plugins.
 
-- [Freqtrade](https://www.freqtrade.io)
+## Source
+
+- [freqtrade.io](https://www.freqtrade.io/)
+- [freqtrade/freqtrade](https://github.com/freqtrade/freqtrade)
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Strategies** | Python + pandas — examples in strategy repo |
+| **Backtest** | Historical candle replay |
+| **Hyperopt** | ML-assisted parameter search (ROI, stops, entries) |
+| **Dry-run** | Paper trading before live keys |
+| **Exchanges** | Major spot and futures venues (see docs per exchange) |
+| **Control** | Telegram bot or WebUI start/stop and PnL |
+
+## Requirements (typical)
+
+- Linux VPS: ~2 GB RAM, 2 vCPU, 1 GB disk
+- Python 3.11+ or Docker (recommended)
+- TA-Lib, git, virtualenv
+
+## Safety
+
+> Educational use only. Always **dry-run** first. Never risk capital you cannot lose.
+
+```bash
+# Quick start path — see official Docker install guide
+docker compose run --rm freqtrade create-userdir --userdir user_data
+```
+
+## Related
+
+- [Cryptocurrencies](./README.md)

--- a/software-engineering/documentation/README.md
+++ b/software-engineering/documentation/README.md
@@ -1,14 +1,26 @@
 ---
 title: Documentation
-description: How to add some life to your Github profile homepage
+description: Personal and project documentation — Obsidian, READMEs, and writing resources.
 ---
 
 # Documentation
 
-[https://obsidian.md/](https://obsidian.md)
+Resources for **personal knowledge bases**, **GitHub presentation**, and **technical writing**.
+
+## Source
+
+- [Obsidian](https://obsidian.md/)
 
 ## In this section
 
-- [GitHub README](./github-readme.md) — How to add some life to your Github profile homepage
-- [Tools](./tools.md)
-- [General](./general.md)
+| Page | Focus |
+|------|--------|
+| [GitHub README](./github-readme.md) | Profile and repo homepage polish |
+| [Tools](./tools.md) | Obsidian — linked notes and plugins |
+| [General](./general.md) | Video on documentation practices |
+
+## Quick picks
+
+- **Daily notes + wikilinks** in Obsidian for capture
+- **README-driven development** for open-source repos
+- **Publish** notes via Obsidian Publish or export to this docs site

--- a/software-engineering/documentation/general.md
+++ b/software-engineering/documentation/general.md
@@ -1,4 +1,18 @@
+---
+title: General
+description: Video resource on documentation and technical writing practices.
+---
+
 # General
 
+Supplementary video on documentation approaches and communicating technical ideas clearly.
 
-<https://www.youtube.com/watch?v=XEtB542_J44>
+## Source
+
+- [YouTube: documentation talk](https://www.youtube.com/watch?v=XEtB542_J44)
+
+## Pair with
+
+- [Tools](./tools.md) — Obsidian for personal knowledge bases
+- [GitHub README](./github-readme.md) — profile and project readme polish
+- [Documentation](./README.md) — section index

--- a/software-engineering/documentation/tools.md
+++ b/software-engineering/documentation/tools.md
@@ -1,3 +1,34 @@
+---
+title: Tools
+description: Obsidian — local-first notes, links, and knowledge bases.
+---
+
 # Tools
 
-<https://obsidian.md>
+**Obsidian** is a local-first markdown notes app for personal knowledge management, journaling, and project docs.
+
+## Source
+
+- [obsidian.md](https://obsidian.md)
+
+## Why use it for documentation
+
+| Feature | Use |
+|---------|-----|
+| **Local files** | Notes stay on your device (offline, private) |
+| **Wikilinks** | `[[page]]` connections between ideas |
+| **Graph view** | Visualize note relationships |
+| **Canvas** | Infinite boards for brainstorming |
+| **Plugins** | Thousands of community extensions |
+| **Open formats** | Plain Markdown — no vendor lock-in |
+| **Sync / Publish** | Optional E2E sync and static site publishing |
+
+## Workflow tips
+
+- One vault per major project or life area
+- Daily notes + linked MOC (map of content) pages
+- Pair with Git for versioned personal docs (see [GitHub README](./github-readme.md))
+
+## Related
+
+- [Documentation](./README.md)

--- a/software-engineering/kubernetes/k3s.md
+++ b/software-engineering/kubernetes/k3s.md
@@ -1,10 +1,50 @@
+---
+title: K3s
+description: Lightweight Kubernetes — single binary, sqlite default, edge/IoT friendly.
+---
+
 # K3s
 
-## Install K3s Master
+**K3s** is a CNCF-certified, production-ready Kubernetes distribution packaged as a **&lt;100 MB** binary — half the memory footprint of full k8s, ideal for edge, IoT, CI, and homelab clusters.
+
+## Source
+
+- [k3s-io/k3s](https://github.com/k3s-io/k3s/blob/master/README.md)
+- [docs.k3s.io](https://docs.k3s.io/)
+
+## What’s different
+
+- Single launcher bundles containerd, Flannel CNI, CoreDNS, Traefik ingress, local-path storage, Helm controller, etc.
+- Default datastore: **SQLite** (etcd, MySQL, Postgres also supported via Kine)
+- Secure defaults; minimal OS deps (kernel + cgroups)
+- Kubelet API exposed to control plane over websocket tunnel (no worker port exposure)
+
+## Quick install (server)
+
+```bash
+curl -sfL https://get.k3s.io | sh -
+sudo kubectl get nodes
+# kubeconfig: /etc/rancher/k3s/k3s.yaml
+# join token: /var/lib/rancher/k3s/server/node-token
+```
+
+## Join agent
+
+```bash
+curl -sfL https://get.k3s.io | K3S_URL=https://myserver:6443 K3S_TOKEN=XXX sh -
+```
+
+## Netmaker / multi-cloud example
+
+When nodes communicate over a WireGuard overlay (e.g. Netmaker `nm-k3s` interface), bind k3s to that IP:
 
 ```bash
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --node-ip 10.11.11.2 --node-external-ip 10.11.11.2 --flannel-iface nm-k3s" sh -
 ```
 
+See [Install K3s (Netmaker tutorial)](../../misc/tutorials/setting-up-k3s-in-lxc-containers-using-netmaker/install-k3s/README.md).
 
-<https://github.com/k3s-io/k3s/blob/master/README.md>
+## Related
+
+- [Kubernetes](./README.md)
+- [Rancher](./rancher.md)

--- a/software-engineering/machine-learning/google-mlkit/README.md
+++ b/software-engineering/machine-learning/google-mlkit/README.md
@@ -1,12 +1,32 @@
 ---
 title: Google MLKit
-description: "\"\\\"Official documentation: [Barcode scanning \\\\\\\\| Google for Developers](https://developers.google.com/ml-kit/vision/barcode-scanning/android)\\\"\""
+description: On-device ML APIs for Android and iOS — vision, language, and more.
 ---
 
 # Google MLKit
 
-[https://developers.google.com/ml-kit/vision/barcode-scanning/android](https://developers.google.com/ml-kit/vision/barcode-scanning/android)
+**ML Kit** brings Google’s on-device machine learning to mobile apps — barcode scanning, face detection, text recognition, and more without shipping large custom models.
+
+## Source
+
+- [ML Kit for developers](https://developers.google.com/ml-kit)
+- [Barcode scanning (Android)](https://developers.google.com/ml-kit/vision/barcode-scanning/android)
 
 ## In this section
 
-- [ML Kit barcode (Android)](./mlkit-barcode-android.md) — Official documentation: [Barcode scanning \| Google for Developers](https://developers.google.com/ml-kit/vision/barcode-scanning/android)
+- [ML Kit barcode (Android)](./mlkit-barcode-android.md) — 1D/2D barcode scanning API
+
+## When to use ML Kit
+
+| Use case | API |
+|----------|-----|
+| QR / product barcodes | Barcode scanning |
+| OCR on device | Text recognition |
+| Faces / poses | Vision APIs |
+| Custom models | TensorFlow Lite integration |
+
+Bundled vs Play Services models trade app size (~200 KB vs ~2.4 MB) for install-time availability — see child page.
+
+## Related
+
+- [Machine Learning](../README.md)

--- a/software-engineering/machine-learning/google-mlkit/mlkit-barcode-android.md
+++ b/software-engineering/machine-learning/google-mlkit/mlkit-barcode-android.md
@@ -1,3 +1,39 @@
+---
+title: ML Kit barcode scanning (Android)
+description: Scan and decode 1D/2D barcodes on Android with ML Kit.
+---
+
 # ML Kit barcode scanning (Android)
 
-Official documentation: [Barcode scanning \| Google for Developers](https://developers.google.com/ml-kit/vision/barcode-scanning/android)
+Recognize and decode barcodes (QR, EAN, PDF417, etc.) on-device with **ML Kit**.
+
+## Source
+
+- [Barcode scanning \| Google for Developers](https://developers.google.com/ml-kit/vision/barcode-scanning/android)
+
+## Install options
+
+| Mode | Gradle dependency | Trade-off |
+|------|-------------------|-----------|
+| **Bundled** | `com.google.mlkit:barcode-scanning:17.3.0` | +~2.4 MB, instant model |
+| **Play Services** | `com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.1` | +~200 KB, may download on first use |
+
+Requires `minSdkVersion` **23+**. Add Google Maven to project `build.gradle`.
+
+## Basic usage pattern
+
+1. Build `InputImage` from CameraX, `Bitmap`, or byte buffer
+2. Create `BarcodeScanner` via `BarcodeScanning.getClient()`
+3. Call `process(image)` and handle `List<Barcode>` (format, raw bytes, corner points)
+
+For simple QR-only flows, Google’s **Code Scanner** API may be faster and permission-light.
+
+## Image quality
+
+- Smallest barcode unit should be **≥ 2 pixels** wide (2D: 2 px tall)
+- EAN-13 ideally **≥ 190 px** wide; dense PDF417 needs more resolution
+
+## Related
+
+- [Google MLKit](./README.md)
+- [Browser BarcodeDetect API](../../browsers/apis/browser-barcodedetect-api-using-image.md)

--- a/software-engineering/machine-learning/openmv.io.md
+++ b/software-engineering/machine-learning/openmv.io.md
@@ -1,5 +1,43 @@
+---
+title: openmv.io
+description: OpenMV Cam — MicroPython machine vision on embedded cameras.
+---
+
 # openmv.io
 
-[https://docs.openmv.io/](https://docs.openmv.io/)
+**OpenMV** boards run **MicroPython** firmware for on-camera machine vision — no host PC required for many pipelines.
 
-<https://docs.openmv.io/>
+## Source
+
+- [OpenMV documentation](https://docs.openmv.io/)
+- [openmv.io](https://openmv.io/)
+- [OpenMV IDE](https://openmv.io/pages/download)
+
+## What you can run on-device
+
+- Face detection (BlazeFace), hand landmarks, YOLOv8 person tracking
+- AprilTag pose, QR and 1D barcodes, color blob tracking
+- Custom TFLite models (e.g. from Roboflow)
+
+## Quick start
+
+1. Install **OpenMV IDE** (Windows/macOS/Linux)
+2. Connect the cam over USB (blue heartbeat LED when ready)
+3. Connect in IDE → run example scripts from the docs
+
+## Core libraries
+
+| Module | Role |
+|--------|------|
+| `csi` | Camera sensor config |
+| `image` | Blobs, features, drawing |
+| `ml` | TFLite inference + postprocessors |
+| `machine` | GPIO, I²C, SPI, UART |
+| `network` / `microdot` | WiFi and tiny HTTP server |
+
+Board-specific pinouts: N6, AE3, H7, RT1062, Nicla Vision, Portenta, etc.
+
+## Related
+
+- [Machine Learning](./README.md)
+- [Google MLKit](./google-mlkit/README.md)

--- a/software-engineering/programming/frontend/README.md
+++ b/software-engineering/programming/frontend/README.md
@@ -1,13 +1,26 @@
 ---
 title: Frontend
-description: "\"\\\"*This page documents **CSS**.*\\\"\""
+description: Frontend notes — JavaScript desktop apps, Laravel/Vite, and CSS.
 ---
 
 # Frontend
 
-Notes and links for **Frontend**.
+Curated notes for **JavaScript** desktop tooling, **Laravel + Vite** migrations, and **CSS** references.
 
 ## In this section
 
-- [Javascript](./javascript/README.md) — "\"Recently, I planned to rewrite my [“Scrum Daily Standup Picker” Electron application](https://github.com/Mokkapps/scrum-daily-standup-pic
-- [CSS](./css.md) — *This page documents **CSS**.*
+| Page | Topic |
+|------|--------|
+| [Javascript](./javascript/README.md) | Quasar/Pinia/Electron, Laravel Vite upgrade |
+| [CSS](./css.md) | CSS patterns and references |
+
+## Highlights
+
+- **Electron + Quasar** — cross-platform desktop from Vue
+- **Laravel 9.19+** — official Vite integration replaces Webpack Mix
+- **CSS** — layout, components, and modern feature notes
+
+## Related
+
+- [Programming](../README.md)
+- [Software Engineering](../../README.md)

--- a/software-engineering/programming/frontend/javascript/README.md
+++ b/software-engineering/programming/frontend/javascript/README.md
@@ -1,13 +1,26 @@
 ---
 title: Javascript
-description: "\"\\\"Recently, I planned to rewrite my [“Scrum Daily Standup Picker” Electron application](https://github.com/Mokkapps/scrum-daily-standup-picker; To make use of the new Vite integration, you will need to update to at least version `9.19.0` of the `laravel/framework`:\\\"\""
+description: JavaScript desktop and full-stack frontend migration notes.
 ---
 
 # Javascript
 
-Notes and links for **Javascript**.
+Imported guides for **Electron desktop apps** and **Laravel’s Vite** migration.
 
 ## In this section
 
-- [Quasar + Pinia + Electron Desktop App](./quasar-+-pinia-+-electron-desktop-app.md) — Recently, I planned to rewrite my [“Scrum Daily Standup Picker” Electron application](https://github.com/Mokkapps/scrum-daily-standup-picker
-- [Laravel Upgrade from Webpack to Vite](./laravel-upgrade-from-webpack-to-vite.md) — To make use of the new Vite integration, you will need to update to at least version `9.19.0` of the `laravel/framework`:
+| Page | Summary |
+|------|---------|
+| [Quasar + Pinia + Electron Desktop App](./quasar-+-pinia-+-electron-desktop-app.md) | Rewrite of the Scrum Daily Standup Picker Electron app using Quasar and Pinia |
+| [Laravel Upgrade from Webpack to Vite](./laravel-upgrade-from-webpack-to-vite.md) | Move Laravel assets to Vite (`laravel/framework` ≥ 9.19.0) |
+
+## Stack notes
+
+**Quasar + Electron** — Vue 3 UI, Pinia state, packaged desktop via Electron; good for internal tools with native menus/tray.
+
+**Laravel + Vite** — `npm run dev` HMR for Blade/Inertia/Vue/React; replace Mix with `@vitejs/plugin-laravel` patterns from the upgrade guide.
+
+## Related
+
+- [Frontend](../README.md)
+- [Capacitor](../../../android-app-development/capacitor.md) — mobile shell for web frontends


### PR DESCRIPTION
## Summary

- 12 software-engineering stub pages enriched with structured content and source links.
- Batch tracker advanced to batch 5.

## Test plan

- [ ] `npm run docs:build`