### PR TITLE
Import stub page content (batch 5)

### DIFF
--- a/scripts/stub-import-batches.json
+++ b/scripts/stub-import-batches.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "next_batch": 5,
+  "next_batch": 6,
   "batches": [
     {
       "id": 1,

--- a/software-engineering/browsers/README.md
+++ b/software-engineering/browsers/README.md
@@ -1,14 +1,27 @@
 ---
 title: Browsers
-description: Browser extensions, web APIs, and CORS troubleshooting notes
+description: Browser extensions, web platform APIs, and CORS troubleshooting.
 ---
 
 # Browsers
 
-Browser extensions, web platform APIs, and CORS troubleshooting.
+Notes on **browser extensions**, **experimental web APIs**, and **CORS** debugging for frontend and PWA work.
 
 ## In this section
 
-- [Extensions](./extensions/README.md) — "\"https://github.com/gildas-lormeau/SingleFile\""
-- [API's](./apis/README.md) — "\"This is the repository for `shape-detection-api`, an experimental API for detecting Shapes (e.g. Faces, Barcodes, Text) in live or still 
-- [CORS Errors](./cors-errors.md) — **Cross-origin resource sharing** (**CORS**) is a mechanism that allows sharing resources outside of the domain from which the resource is f
+| Page | Topic |
+|------|--------|
+| [Extensions](./extensions/README.md) | SingleFile and related tools |
+| [API's](./apis/README.md) | Shape Detection, Barcode Detection, image scanning |
+| [CORS Errors](./cors-errors.md) | Cross-origin resource sharing troubleshooting |
+
+## Quick links
+
+- Save complete pages offline → [SingleFile](./extensions/singlefile.md)
+- Scan barcodes in the browser → [Barcode Detection API](./apis/barcode-detection-api.md)
+- Fix `Access-Control-Allow-Origin` issues → [CORS Errors](./cors-errors.md)
+
+## Related
+
+- [Software Engineering](../README.md)
+- [Frontend](../programming/frontend/README.md)

--- a/software-engineering/browsers/apis/README.md
+++ b/software-engineering/browsers/apis/README.md
@@ -1,14 +1,31 @@
 ---
-title: "\"\\\"API's\\\"\""
-description: "\"\\\"This is the repository for `shape-detection-api`, an experimental API for detecting Shapes (e.g. Faces, Barcodes, Text) in live or still ima; **Code**\\\"\""
+title: Browser APIs
+description: Shape Detection and barcode scanning web platform APIs.
 ---
 
-# API's
+# Browser APIs
 
-Notes and links for **API's**.
+Experimental and shipping **web platform APIs** for detecting faces, barcodes, and shapes in camera streams or images.
+
+## Source
+
+- [WICG shape-detection-api](https://wicg.github.io/shape-detection-api)
+- [Barcode Detection API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Barcode_Detection_API)
 
 ## In this section
 
-- [Shape Detection](./shape-detection/README.md) — "\"This version:[https://wicg.github.io/shape-detection-api](https://wicg.github.io/shape-detection-api)Issue Tracking:[GitHub](https://gith
-- [Barcode Detection API](./barcode-detection-api.md) — **Code**
-- [Browser BarcodeDetect API using Image](./browser-barcodedetect-api-using-image.md)
+| Page | API |
+|------|-----|
+| [Shape Detection](./shape-detection/README.md) | WICG spec — faces, barcodes, text in live/still images |
+| [Barcode Detection API](./barcode-detection-api.md) | `BarcodeDetector` interface |
+| [Browser BarcodeDetect API using Image](./browser-barcodedetect-api-using-image.md) | Image-based scanning example |
+
+## Browser support notes
+
+- Barcode Detection is Chromium-first; check `BarcodeDetector` availability before shipping
+- Prefer **HTTPS** + user gesture for camera access
+- Fallback to [ML Kit](../../machine-learning/google-mlkit/mlkit-barcode-android.md) on native mobile
+
+## Related
+
+- [Browsers](../README.md)

--- a/software-engineering/browsers/extensions/README.md
+++ b/software-engineering/browsers/extensions/README.md
@@ -1,12 +1,24 @@
 ---
 title: Extensions
-description: "\"\\\"https://github.com/gildas-lormeau/SingleFile\\\"\""
+description: Browser extensions for archiving and developer workflows.
 ---
 
 # Extensions
 
-Notes and links for **Extensions**.
+Curated **browser extensions** useful for documentation capture and debugging.
+
+## Source
+
+- [gildas-lormeau/SingleFile](https://github.com/gildas-lormeau/SingleFile)
 
 ## In this section
 
-- [SingleFile](./singlefile.md) — "https://github.com/gildas-lormeau/SingleFile"
+- [SingleFile](./singlefile.md) — save a complete web page into one HTML file
+
+## Why extensions here
+
+Extensions complement this docs repo — archive reference pages, capture auth-gated UIs for offline notes, and preserve assets when ingesting external guides.
+
+## Related
+
+- [Browsers](../README.md)

--- a/software-engineering/containerisation/docker.md
+++ b/software-engineering/containerisation/docker.md
@@ -1,15 +1,45 @@
 ---
 title: Docker
-description: "\"\\\"Run Docker commands without sudo; \\\\\\\\ ![Devin Norgarb](https://chat.openai.com/\\\\\\\\_next/image?url=https%3A%2F%2Flh3.googleusercontent.com%2Fa%2FAGNmyxYYwN6bMkVgnW1hgjVNccFzedHnhA\\\"\""
+description: Container platform for developing, shipping, and running applications.
 ---
 
 # Docker
 
-## Overview
+**Docker** packages applications and dependencies into **containers** — portable, isolated environments that run consistently from laptop to production.
 
-*This page documents **Docker**.*
+## Source
+
+- [Docker documentation](https://docs.docker.com/)
+- [What is Docker?](https://docs.docker.com/get-started/overview/)
+
+## Why Docker
+
+| Benefit | Detail |
+|---------|--------|
+| **Consistency** | Same image in dev, CI, and prod |
+| **Isolation** | Processes share the host kernel, not a full VM |
+| **Speed** | Lightweight starts vs hypervisor VMs |
+| **Ecosystem** | Dockerfile, Compose, Hub registries |
+
+## Core concepts
+
+- **Image** — read-only template (layers from Dockerfile instructions)
+- **Container** — running instance of an image
+- **Registry** — image storage (Docker Hub or private)
+- **Compose** — multi-container apps via `docker-compose.yml`
+
+## Quick example
+
+```bash
+docker run -it --rm ubuntu /bin/bash
+```
 
 ## In this section
 
-- [Run docker without sudo](./docker/run-docker-without-sudo.md) — Run Docker commands without sudo
-- [MultiArch Builds](./docker/multiarch-builds.md) — \ ![Devin Norgarb](https://chat.openai.com/\_next/image?url=https%3A%2F%2Flh3.googleusercontent.com%2Fa%2FAGNmyxYYwN6bMkVgnW1hgjVNccFzedHnhA
+- [Run docker without sudo](./docker/run-docker-without-sudo.md)
+- [MultiArch Builds](./docker/multiarch-builds.md)
+
+## Related
+
+- [Containerisation](./README.md)
+- [Kubernetes](../kubernetes/README.md)

--- a/software-engineering/kubernetes/rancher.md
+++ b/software-engineering/kubernetes/rancher.md
@@ -1,5 +1,35 @@
+---
+title: Rancher
+description: Multi-cluster Kubernetes management — auth, monitoring, Fleet deployments.
+---
+
 # Rancher
 
-Kubernetes cluster management platform.
+**Rancher** is a Kubernetes management platform for provisioning, importing, and operating clusters across data centers and cloud providers.
 
-- [Rancher docs](https://rancher.com/docs/)
+## Source
+
+- [Rancher documentation](https://ranchermanager.docs.rancher.com/)
+- [rancher/rancher](https://github.com/rancher/rancher)
+
+## What Rancher adds
+
+| Capability | Description |
+|------------|-------------|
+| **Cluster lifecycle** | Provision hosted clusters or import existing k8s/k3s |
+| **Centralized RBAC** | One auth layer across all attached clusters |
+| **Observability** | Monitoring, alerting, log shipping integrations |
+| **App delivery** | Helm catalog + **Fleet** GitOps for workloads |
+| **Multi-tenancy** | Projects and namespaces with policy guardrails |
+
+## Typical setup
+
+1. Install Rancher on a management cluster (or Docker single-node for lab)
+2. Import or create downstream clusters (RKE2, k3s, EKS, GKE, etc.)
+3. Deploy apps via Helm charts or Fleet repos
+4. Enforce global roles and audit from the Rancher UI
+
+## Related
+
+- [Kubernetes](./README.md)
+- [k3s](./k3s.md) — lightweight clusters Rancher can import

--- a/software-engineering/networking/vpn/netmaker/README.md
+++ b/software-engineering/networking/vpn/netmaker/README.md
@@ -1,14 +1,50 @@
 ---
 title: NetMaker
-description: "\"\\\"This quick start guide is an **opinionated** guide for getting up and running with Netmaker as quickly as possible.\\\"\""
+description: WireGuard automation — mesh VPNs, remote access, and multi-cloud networking.
 ---
 
 # NetMaker
 
-<https://itnext.io/8-use-cases-for-kubernetes-over-vpn-unlocking-multicloud-flexibility-3958dab2219f>
+**Netmaker** automates **WireGuard** networks from homelab to enterprise — mesh VPNs, site-to-site links, remote access gateways, and Kubernetes overlays.
 
-<https://github.com/gravitl/netmaker>
+## Source
+
+- [gravitl/netmaker](https://github.com/gravitl/netmaker)
+- [docs.netmaker.io](https://docs.netmaker.io/)
+- [8 use cases for Kubernetes over VPN](https://itnext.io/8-use-cases-for-kubernetes-over-vpn-unlocking-multicloud-flexibility-3958dab2219f)
+
+## Features
+
+| Area | Capabilities |
+|------|----------------|
+| **Networks** | WireGuard mesh, site-to-site, remote access gateways |
+| **Management** | Admin UI, OAuth, private DNS, ACLs |
+| **Clients** | Linux, Docker, Mac, Windows agents (`netclient`) |
+
+## Quick self-host install
+
+1. Ubuntu 24.04 VM with static public IP
+2. Open ports **443**, **51821** TCP/UDP
+3. Wildcard DNS `*.netmaker.example.com` → VM IP (recommended)
+4. Run:
+
+```bash
+sudo wget -qO /root/nm-quick.sh https://raw.githubusercontent.com/gravitl/netmaker/master/scripts/nm-quick.sh
+sudo chmod +x /root/nm-quick.sh && sudo /root/nm-quick.sh
+```
+
+Managed option: [account.netmaker.io](https://account.netmaker.io)
+
+## Common use cases
+
+- Cross-cloud **k3s** clusters (see [Install K3s](../../../misc/tutorials/setting-up-k3s-in-lxc-containers-using-netmaker/install-k3s/README.md))
+- Homelab remote access without exposing services publicly
+- Multi-site private networking with kernel WireGuard performance
 
 ## In this section
 
-- [Installation](./installation.md) — This quick start guide is an **opinionated** guide for getting up and running with Netmaker as quickly as possible.
+- [Installation](./installation.md) — opinionated quick-start guide
+
+## Related
+
+- [VPN](../README.md)

--- a/software-engineering/networking/web-sockets/README.md
+++ b/software-engineering/networking/web-sockets/README.md
@@ -1,13 +1,25 @@
 ---
 title: Web Sockets
-description: "\"\\\"![](https://miro.medium.com/max/942/1\\\\\\\\*SD2DJOX\\\\\\\\_RgOZk9y1fJL\\\\\\\\_Zg.png); Testing Websockets\\\"\""
+description: WebSocket testing tools and Socket.IO debugging notes.
 ---
 
 # Web Sockets
 
-Notes and links for **Web Sockets**.
+Resources for **testing WebSocket** connections and debugging **Socket.IO** traffic during development.
 
 ## In this section
 
-- [Testing Socket.IO with Postman](./testing-socketio-with-postman.md) — ![](https://miro.medium.com/max/942/1\*SD2DJOX\_RgOZk9y1fJL\_Zg.png)
-- [Socket Client Tool](./socket-client-tool.md) — Testing Websockets
+| Page | Focus |
+|------|--------|
+| [Testing Socket.IO with Postman](./testing-socketio-with-postman.md) | Debug Socket.IO from Postman |
+| [Socket Client Tool](./socket-client-tool.md) | Browser-based WS/Socket.IO testers |
+
+## When to use
+
+- Validate handshake, auth headers, and message payloads before production
+- Reproduce intermittent disconnects with manual ping/pong tests
+- Compare raw WebSocket vs Socket.IO event framing
+
+## Related
+
+- [Networking](../README.md)

--- a/software-engineering/networking/web-sockets/socket-client-tool.md
+++ b/software-engineering/networking/web-sockets/socket-client-tool.md
@@ -1,9 +1,35 @@
 ---
-description: Testing Websockets
+title: Socket Client Tool
+description: Browser tools for testing WebSocket and Socket.IO endpoints.
 ---
 
 # Socket Client Tool
 
-<https://amritb.github.io/socketio-client-tool>
+Browser-based utilities for manually connecting to **WebSocket** and **Socket.IO** servers during development.
 
-<https://www.piesocket.com/websocket-tester>
+## Source
+
+- [Socket.IO Client Tool](https://amritb.github.io/socketio-client-tool) — connect, emit, and listen to Socket.IO events
+- [PieSocket WebSocket Tester](https://www.piesocket.com/websocket-tester) — raw WebSocket client in the browser
+
+## Socket.IO Client Tool
+
+- Enter server URL and optional path/query
+- Emit named events with JSON payloads
+- Watch inbound events in a live log
+- Useful for verifying namespaces, rooms, and auth middleware
+
+## PieSocket WebSocket Tester
+
+- Plain WebSocket connect/send without Socket.IO framing
+- Good for STOMP, custom protocols, or pre-Socket.IO handshake debugging
+
+## Tips
+
+- Test both `ws://` (local) and `wss://` (TLS) endpoints
+- Mirror production headers (`Authorization`, cookies) when auth is header-based
+- Pair with [Testing Socket.IO with Postman](./testing-socketio-with-postman.md) for collection-based regression
+
+## Related
+
+- [Web Sockets](./README.md)

--- a/software-engineering/shopify-dev/carrier-services.md
+++ b/software-engineering/shopify-dev/carrier-services.md
@@ -1,7 +1,43 @@
+---
+title: Carrier Services
+description: Shopify carrier-calculated shipping rates via app callback URL.
+---
+
 # Carrier Services
 
+A **CarrierService** lets your Shopify app provide **real-time shipping rates** at checkout by responding to rate requests at a public `callback_url`.
 
-## Overview
+## Source
 
-*This page documents **Carrier Services**.*
+- [CarrierService (REST Admin API)](https://shopify.dev/docs/api/admin-rest/latest/resources/carrierservice)
+- Prefer **GraphQL Admin API** for new apps (REST legacy from Oct 2024)
 
+## How it works
+
+1. App registers a carrier service with `name`, `callback_url`, and `service_discovery`
+2. At checkout Shopify **POSTs** cart origin, destination, items, and currency to your URL
+3. Your server returns JSON `{ "rates": [ … ] }` with `service_name`, `service_code`, `total_price` (subunits), `currency`, optional delivery dates
+4. Empty `rates` + 2xx = “cannot ship”; 4xx/5xx triggers backup rates
+
+## Access requirements
+
+- App scope: `write_shipping`
+- Store must be Advanced Shopify+, Shopify annual with carrier feature, or a **development store**
+
+## Rate limits & caching
+
+- Dynamic timeouts: **10s / 5s / 3s** based on requests per minute per shop-app pair
+- Shopify caches identical rate requests ~**15 minutes** (variant IDs, addresses, weights, box dimensions)
+
+## Create example
+
+```bash
+curl -d '{"carrier_service":{"name":"My Rates","callback_url":"https://shipping.example.com/rates","service_discovery":true}}' \
+  -X POST "https://{shop}.myshopify.com/admin/api/2026-01/carrier_services.json" \
+  -H "X-Shopify-Access-Token: {token}" -H "Content-Type: application/json"
+```
+
+## Related
+
+- [Shopify Dev](./README.md)
+- [Fulfillment Orders](./fulfilment-orders.md)

--- a/software-engineering/shopify-dev/fulfilment-orders.md
+++ b/software-engineering/shopify-dev/fulfilment-orders.md
@@ -1,7 +1,46 @@
+---
+title: Fulfillment Orders
+description: Shopify FulfillmentOrder workflow for apps and fulfillment services.
+---
+
 # Fulfillment Orders
 
+**Fulfillment orders** model how Shopify splits an order into fulfillable groups per location and delivery method — the modern API for fulfillment apps.
 
-## Overview
+## Source
 
-*This page documents **Fulfillment Orders**.*
+- [About fulfillment services](https://shopify.dev/docs/apps/fulfillment/fulfillment-service-apps)
+- [Migrate to fulfillment orders](https://shopify.dev/docs/apps/fulfillment/migrate-to-fulfillment-orders)
 
+## Key objects
+
+| Object | Role |
+|--------|------|
+| `Order` | Parent order with one or more fulfillment orders |
+| `FulfillmentOrder` | Line items fulfilled from one location / delivery method |
+| `FulfillmentOrderLineItem` | Quantities to fulfill per FO |
+| `Fulfillment` | Shipment record (tracking, items) |
+| `FulfillmentService` | 3PL / print-on-demand service with its own `Location` |
+
+## Lifecycle (fulfillment service app)
+
+1. Merchant or app submits a **fulfillment request** for an FO
+2. Service **accepts** or **rejects** the request
+3. Service creates **fulfillments** with tracking
+4. Cancellation requests can flow both directions via dedicated webhooks
+
+## Webhooks (selection)
+
+- `fulfillment_orders/fulfillment_request_submitted`
+- `fulfillment_orders/fulfillment_request_accepted` / `_rejected`
+- `fulfillment_orders/cancelled`
+- `fulfillment_orders/order_routing_complete`
+
+## Split carts
+
+Orders may include multiple delivery methods (ship + pickup). Iterate **all fulfillment orders** — never assume a single method per order.
+
+## Related
+
+- [Track orders through third-party marketplaces](./track-orders-placed-through-third-party-marketplaces.md)
+- [Carrier Services](./carrier-services.md)

--- a/software-engineering/tooling-extras/testing/README.md
+++ b/software-engineering/tooling-extras/testing/README.md
@@ -1,12 +1,37 @@
 ---
 title: Testing
-description: Testing — Frontend
+description: Frontend test infrastructure — Cypress dashboards and sorry-cypress.
 ---
 
 # Testing
 
-Notes and links for **Testing**.
+Notes on **frontend test orchestration** and self-hosted Cypress result dashboards.
 
 ## In this section
 
-- [Frontend](./frontend/README.md) — "\"Running the full sorry-cypress kit - setting up web dashboard to store and browse test results. The [basic](https://docs.sorry-cypress.de
+- [Frontend](./frontend/README.md) — sorry-cypress and Cypress reporting
+
+## sorry-cypress (highlight)
+
+**sorry-cypress** is an open-source drop-in replacement for the Cypress Dashboard — store screenshots, videos, and run history on your own infra.
+
+## Source
+
+- [sorry-cypress docs](https://docs.sorry-cypress.dev/)
+- [sorry-cypress/sorry-cypress](https://github.com/sorry-cypress/sorry-cypress)
+
+## Typical stack
+
+| Component | Role |
+|-----------|------|
+| **Director** | Receives Cypress run uploads |
+| **API** | GraphQL/REST for queries |
+| **Dashboard** | Web UI to browse specs and failures |
+| **S3 / MinIO** | Artifact storage |
+
+Point Cypress at your director URL via `CYPRESS_API_URL` and project record key.
+
+## Related
+
+- [Automation](../automation/README.md) — Cypress browser E2E
+- [Tooling Extras](./../README.md)

--- a/software-engineering/webrtc/README.md
+++ b/software-engineering/webrtc/README.md
@@ -1,14 +1,38 @@
 ---
 title: WebRTC
-description: WebRTC resources, open-source projects, testing tools, and STUN/TURN server setup
+description: Real-time voice/video — open-source stacks, testing, STUN/TURN setup.
 ---
 
 # WebRTC
 
-WebRTC (Web Real-Time Communication) resources, including open-source projects, testing tools, and STUN/TURN server setup.
+**WebRTC** enables peer-to-peer audio, video, and data channels in browsers and native apps without proprietary plugins.
+
+## What WebRTC provides
+
+- Capture from camera/mic (`getUserMedia`)
+- Encrypted transports (DTLS-SRTP)
+- NAT traversal via **ICE** with **STUN/TURN** servers
+- Data channels for arbitrary binary/text messages
 
 ## In this section
 
-- [Open-source WebRTC Projects](./opensource-webrtc-projects.md) — "'Credit: https://medevel.com/13-os-webrtc-server/'"
-- [Testing WebRTC](./testing-webrtc.md)
-- [Setting up STUN and TURN servers](./setting-up-stun-and-turn-servers.md) — 1. Make sure that you're using latest up-to-dated Ubuntu (TLS 14+) 2. ### Find a useful FTP link for your region.
+| Page | Focus |
+|------|--------|
+| [Open-source WebRTC Projects](./opensource-webrtc-projects.md) | Kurento, Janus, mediasoup, etc. |
+| [Testing WebRTC](./testing-webrtc.md) | Debug connectivity and media paths |
+| [Setting up STUN and TURN servers](./setting-up-stun-and-turn-servers.md) | Relay for restrictive NATs |
+
+## Architecture tip
+
+```
+Browser A ←→ STUN (discover reflexive addr)
+         ↘ TURN (relay when P2P fails) ↙
+Browser B
+```
+
+Most production apps need a **signaling server** (WebSocket/HTTP) to exchange SDP offers/answers and ICE candidates — WebRTC does not define signaling.
+
+## Related
+
+- [Web Sockets](../networking/web-sockets/README.md)
+- [Software Engineering](../README.md)


### PR DESCRIPTION
## Summary

- 12 software-engineering stub pages (networking, browsers, containers, Shopify, WebRTC, testing).
- Batch tracker advanced to batch 6 (final planned batch).

## Test plan

- [ ] `npm run docs:build`