### PR TITLE
fix(ci): restore audit test fixture

### DIFF
--- a/scripts/fixtures/audit-sample.md
+++ b/scripts/fixtures/audit-sample.md
@@ -1,22 +1,17 @@
 ---
 title: Audit fixture
-description: Reference notes and links for Audit fixture in the scripts section.
 ---
 
-# Audit fixture
+# Sample
 
-## Source
-- https://example.com/x.png
+![local missing](./missing.png)
 
-## Summary
+[internal link](./also-missing.md)
 
-- Covers key material related to **Audit fixture**.
-- Consolidates the original source links for quick retrieval.
-- Use this page as a launch point before drilling into implementation details.
+![external](https://example.com/x.png)
 
-## Related pages
+[anchor only](#section)
 
-- [local missing](./missing.png)
-- [internal link](./also-missing.md)
-- [in fence](./ignored.png)
-- [Summary Navigation Sample](./summary-navigation-sample.md)
+```markdown
+![in fence](./ignored.png)
+```

--- a/scripts/stub-import-batches.json
+++ b/scripts/stub-import-batches.json
@@ -180,7 +180,6 @@
         "robotics/ros/README.md",
         "robotics/ros/init-ros-melodic/README.md",
         "robotics/ros/ros-guide/README.md",
-        "scripts/fixtures/audit-sample.md",
         "self-hosting/hardware/README.md",
         "self-hosting/hardware/ibm-systemx-x3690.md",
         "self-hosting/sentry/README.md",


### PR DESCRIPTION
## Summary
- Restore `scripts/fixtures/audit-sample.md` to its original test content (stub import batch 7 had overwritten it).
- Remove the fixture from `stub-import-batches.json` so it is not replaced again.
- Unblocks VitePress deploy after PR #50 merge.

## Test plan
- [x] `npm run docs:test` — 22/22 pass