### PR TITLE
fix(ci): skip artifact prune without gh CLI

### DIFF
--- a/scripts/prune-action-artifacts.sh
+++ b/scripts/prune-action-artifacts.sh
@@ -13,8 +13,8 @@ if [ "$#" -eq 0 ]; then
 fi
 
 if ! command -v gh >/dev/null 2>&1; then
-  echo "gh CLI required" >&2
-  exit 1
+  echo "[prune-action-artifacts] gh CLI not found — skipping artifact prune."
+  exit 0
 fi
 
 log() { echo "[prune-action-artifacts] $*"; }


### PR DESCRIPTION
## Summary
- Skip artifact pruning on self-hosted runners when `gh` is not installed (exit 0 with log message).
- Unblocks VitePress build/deploy after PR #51.

## Test plan
- [x] Script exits 0 when gh is missing
- [ ] VitePress workflow completes on self-hosted runner