### PR TITLE
fix(ci): VitePress build OOM on self-hosted

### DIFF
--- a/.github/workflows/vitepress.yml
+++ b/.github/workflows/vitepress.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Build VitePress site
         env:
+          NODE_OPTIONS: --max-old-space-size=4096
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
         run: npm run docs:build
 


### PR DESCRIPTION
## Summary
- Set `NODE_OPTIONS=--max-old-space-size=4096` for the VitePress build step.

## Root cause
Self-hosted runner hit JavaScript heap OOM (~1GB default) during `docs:build` page rendering after PR #53.

## Test plan
- [ ] VitePress workflow completes and deploys to gh-pages