### PR TITLE
fix(docs): render app icons with img tags instead of CSS backgrounds

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -149,6 +149,16 @@
     transform 0.22s ease;
 }
 
+.vp-doc a.app-card {
+  font-weight: inherit;
+  color: inherit;
+  text-decoration: none;
+}
+
+.vp-doc a.app-card:hover {
+  color: inherit;
+}
+
 .VPHome .app-card:hover {
   border-color: color-mix(in srgb, var(--vp-c-brand-1) 55%, var(--vp-c-divider));
   box-shadow:
@@ -163,20 +173,10 @@
   height: 72px;
   border-radius: 18px;
   flex-shrink: 0;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
+  object-fit: cover;
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--vp-c-divider) 80%, transparent),
     0 4px 14px color-mix(in srgb, var(--vp-c-text-1) 8%, transparent);
-}
-
-.VPHome .app-card--gps-remote .app-icon {
-  background-image: url("/apps/gps-remote-icon.png");
-}
-
-.VPHome .app-card--sofly .app-icon {
-  background-image: url("/apps/sofly-icon.png");
 }
 
 .VPHome .app-body {

--- a/index.md
+++ b/index.md
@@ -68,8 +68,8 @@ features:
 
 <div class="apps-grid">
 
-<a class="app-card app-card--gps-remote" href="https://play.google.com/store/apps/details?id=com.devsdev.gpsremote" target="_blank" rel="noopener noreferrer">
-  <span class="app-icon" role="img" aria-label="GPS Remote for Osmo Action"></span>
+<a class="app-card app-card--gps-remote no-icon" href="https://play.google.com/store/apps/details?id=com.devsdev.gpsremote" target="_blank" rel="noopener noreferrer">
+  <img class="app-icon" src="/apps/gps-remote-icon.png" alt="GPS Remote for Osmo Action" width="72" height="72" loading="lazy" decoding="async">
   <div class="app-body">
     <div class="app-meta">
       <h3 class="app-name">GPS Remote for Osmo Action</h3>
@@ -80,8 +80,8 @@ features:
   </div>
 </a>
 
-<a class="app-card app-card--sofly" href="https://play.google.com/store/apps/details?id=flight.track" target="_blank" rel="noopener noreferrer">
-  <span class="app-icon" role="img" aria-label="SoFly"></span>
+<a class="app-card app-card--sofly no-icon" href="https://play.google.com/store/apps/details?id=flight.track" target="_blank" rel="noopener noreferrer">
+  <img class="app-icon" src="/apps/sofly-icon.png" alt="SoFly" width="72" height="72" loading="lazy" decoding="async">
   <div class="app-body">
     <div class="app-meta">
       <h3 class="app-name">SoFly</h3>

--- a/software-engineering/android-app-development/play-google-com-gps-remote-for-osmo-action.md
+++ b/software-engineering/android-app-development/play-google-com-gps-remote-for-osmo-action.md
@@ -13,7 +13,7 @@ description: "Notes on GPS Remote for Osmo Action."
 
 ## Content
 
-![GPS Remote for Osmo Action icon](./assets/play-google-com-gps-remote-for-osmo-action/icon.png)
+![GPS Remote for Osmo Action icon](/apps/gps-remote-icon.png)
 
 **Developer:** Devin Norgarb · **Category:** Photography · **Updated:** Jun 8, 2026
 
@@ -69,7 +69,7 @@ This is a third-party utility, not an official DJI or Mimo app. Features depend 
 
 ## Related app — SoFly
 
-![SoFly icon](./assets/play-google-com-gps-remote-for-osmo-action/sofly-icon.png)
+![SoFly icon](/apps/sofly-icon.png)
 
 **Play Store:** [SoFly — flight tracking & logging](https://play.google.com/store/apps/details?id=flight.track) · **Category:** Maps & Navigation · **Updated:** Jun 18, 2026
 


### PR DESCRIPTION
## Summary
- Replace empty `<span>` + CSS `background-image` app icons on the home page with `<img src="/apps/...">` elements so icons render reliably inside VitePress `.vp-doc` content.
- Neutralize `.vp-doc` link underlines on app cards and add `no-icon` to suppress the external-link glyph overlay.
- Point app detail page icon images at the same `/apps/` public assets as the home page.

## Test plan
- [x] `npm run docs:build` succeeds locally
- [ ] CI VitePress workflow passes
- [ ] After deploy, home page Apps section shows GPS Remote and SoFly icons
- [ ] App detail page icons load at `/software-engineering/android-app-development/play-google-com-gps-remote-for-osmo-action.html`